### PR TITLE
Fix passwords

### DIFF
--- a/ca/django_ca/management/commands/init_ca.py
+++ b/ca/django_ca/management/commands/init_ca.py
@@ -85,8 +85,6 @@ class Command(BaseCommand, CertificateAuthorityDetailMixin):
 
         try:
             password = options['password'][0]
-            if password == '':  # pragma: no cover
-               raise ValueError()
         except:
             password = getpass()
         finally:

--- a/ca/django_ca/management/commands/init_ca.py
+++ b/ca/django_ca/management/commands/init_ca.py
@@ -30,7 +30,6 @@ from django_ca import ca_settings
 from django_ca.models import CertificateAuthority
 from django_ca.management.base import BaseCommand
 from django_ca.management.base import KeySizeAction
-from django.utils.encoding import force_bytes
 from ..base import CertificateAuthorityDetailMixin
 
 
@@ -92,7 +91,7 @@ class Command(BaseCommand, CertificateAuthorityDetailMixin):
             password = None
 
         if password is not None:
-            password = force_bytes(password)
+            password = str.encode(password)
 
 
         # filter empty values in the subject

--- a/ca/django_ca/management/commands/init_ca.py
+++ b/ca/django_ca/management/commands/init_ca.py
@@ -30,6 +30,7 @@ from django_ca import ca_settings
 from django_ca.models import CertificateAuthority
 from django_ca.management.base import BaseCommand
 from django_ca.management.base import KeySizeAction
+from django.utils.encoding import force_bytes
 from ..base import CertificateAuthorityDetailMixin
 
 
@@ -86,14 +87,13 @@ class Command(BaseCommand, CertificateAuthorityDetailMixin):
         try:
             password = options['password'][0]
         except:
-            password = getpass()
+            password = ''
         finally:
             if password == '':
-                # Allow empty password
                 password = None
             else:
                 # cast str to bytes
-                password = str.encode(password)
+                password = force_bytes(password)
 
 
         # filter empty values in the subject

--- a/ca/django_ca/management/commands/init_ca.py
+++ b/ca/django_ca/management/commands/init_ca.py
@@ -109,6 +109,6 @@ class Command(BaseCommand, CertificateAuthorityDetailMixin):
                 issuer_alt_name=options['issuer_alt_name'],
                 crl_url=options['crl_url'],
                 ocsp_url=options['ocsp_url'],
-                name=name, subject=subject, password=options['password'])
+                name=name, subject=subject, password=password)
         except Exception as e:
             raise CommandError(e)

--- a/ca/django_ca/management/commands/init_ca.py
+++ b/ca/django_ca/management/commands/init_ca.py
@@ -89,13 +89,10 @@ class Command(BaseCommand, CertificateAuthorityDetailMixin):
             if password == '':
                 password = getpass()
         except:
-            password = ''
-        finally:
-            if password == '':
-                password = None
-            else:
-                # cast str to bytes
-                password = force_bytes(password)
+            password = None
+
+        if password is not None:
+            password = force_bytes(password)
 
 
         # filter empty values in the subject

--- a/ca/django_ca/management/commands/init_ca.py
+++ b/ca/django_ca/management/commands/init_ca.py
@@ -86,6 +86,8 @@ class Command(BaseCommand, CertificateAuthorityDetailMixin):
 
         try:
             password = options['password'][0]
+            if password == '':
+                password = getpass()
         except:
             password = ''
         finally:

--- a/ca/django_ca/management/commands/init_ca.py
+++ b/ca/django_ca/management/commands/init_ca.py
@@ -83,8 +83,20 @@ class Command(BaseCommand, CertificateAuthorityDetailMixin):
         if not os.path.exists(ca_settings.CA_DIR):  # pragma: no cover
             os.makedirs(ca_settings.CA_DIR)
 
-        if options['password'] == '':  # pragma: no cover
-            options['password'] = getpass()
+        try:
+            password = options['password'][0]
+            if password == '':  # pragma: no cover
+               raise ValueError()
+        except:
+            password = getpass()
+        finally:
+            if password == '':
+                # Allow empty password
+                password = None
+            else:
+                # cast str to bytes
+                password = str.encode(password)
+
 
         # filter empty values in the subject
         subject.setdefault('CN', name)


### PR DESCRIPTION
This fixes #10 I've taken a bit of a guess at the what the original code was trying to achieve:

if no password argument is present, no password is used. 
If password is an empty string `--password=''` the getpass() is called for user input.

The password is set to bytes rather than str, also argparse returns a single value list when `--nargs=1`.

Any feedback or questions would be appreciated.

Thanks,

Tim.
