### PR TITLE
Allow valid wildcard domains to be parsed without error

### DIFF
--- a/ca/django_ca/tests/tests_command_sign_cert.py
+++ b/ca/django_ca/tests/tests_command_sign_cert.py
@@ -15,7 +15,8 @@
 
 import os
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 
 from cryptography.hazmat.primitives.serialization import Encoding
 

--- a/ca/django_ca/tests/tests_command_sign_cert.py
+++ b/ca/django_ca/tests/tests_command_sign_cert.py
@@ -15,7 +15,7 @@
 
 import os
 from collections import OrderedDict
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from cryptography.hazmat.primitives.serialization import Encoding
 
@@ -255,10 +255,13 @@ class SignCertTestCase(DjangoCAWithCSRTestCase):
 
     def test_expiry_too_late(self):
         expires = self.ca.expires + timedelta(days=3)
+        time_left = (self.ca.expires - datetime.now()).days
         stdin = six.StringIO(self.csr_pem)
 
         with self.assertRaisesRegex(
-                CommandError, '^Certificate would outlive CA, maximum expiry for this CA is 3646 days\.$'):
+                CommandError,
+                '^Certificate would outlive CA, maximum expiry for this CA is {} days\.$'.format(time_left)
+        ):
             self.cmd('sign_cert', alt=['example.com'], expires=expires, stdin=stdin)
 
     def test_no_cn_or_san(self):

--- a/ca/django_ca/utils.py
+++ b/ca/django_ca/utils.py
@@ -338,6 +338,21 @@ def parse_general_name(name):
     Traceback (most recent call last):
         ...
     idna.core.IDNAError: Empty domain
+
+
+    Wildcard subdomains are allowed in DNS entries, however RFC 2595 limits their use to a single
+    wildcard in the outermost level
+
+    >>> parse_general_name('*.example.com')
+    'DNS:*.example.com'
+    >>> parse_general_name('*.*.example.com')
+    Traceback (most recent call last):
+    ...
+    idna.core.IDNAError: The label * is not a valid A-label
+    >>> parse_general_name('domain.*.example.com')
+    Traceback (most recent call last):
+    ...
+    idna.core.IDNAError: The label * is not a valid A-label
     """
     name = force_text(name)
     typ = None

--- a/ca/django_ca/utils.py
+++ b/ca/django_ca/utils.py
@@ -402,7 +402,8 @@ def parse_general_name(name):
     elif typ == 'dirname':
         return x509.DirectoryName(x509_name(name))
     else:
-        idna.encode(name)  # fails if this is an invalid domain name
+        # fails if this is an invalid domain name
+        idna.encode(name[2:] if name.startswith("*.") else name)
         return x509.DNSName(name)
 
 

--- a/ca/django_ca/utils.py
+++ b/ca/django_ca/utils.py
@@ -342,17 +342,26 @@ def parse_general_name(name):
 
     Wildcard subdomains are allowed in DNS entries, however RFC 2595 limits their use to a single
     wildcard in the outermost level
-
     >>> parse_general_name('*.example.com')
     'DNS:*.example.com'
-    >>> parse_general_name('*.*.example.com')
+    >>> try:
+    ...     parse_general_name('*.*.example.com')
+    ... except idna.core.InvalidCodepoint:
+    ...     raise Exception("Wildcard error")
+    ... except idna.core.IDNAError:
+    ...     raise Exception("Wildcard error")
     Traceback (most recent call last):
     ...
-    idna.core.IDNAError: The label * is not a valid A-label
-    >>> parse_general_name('domain.*.example.com')
+    Exception: Wildcard error
+    >>> try:
+    ...     parse_general_name('domain.*.example.com')
+    ... except idna.core.InvalidCodepoint:
+    ...     raise Exception("Wildcard error")
+    ... except idna.core.IDNAError:
+    ...     raise Exception("Wildcard error")
     Traceback (most recent call last):
     ...
-    idna.core.IDNAError: The label * is not a valid A-label
+    Exception: Wildcard error
     """
     name = force_text(name)
     typ = None


### PR DESCRIPTION
#24  Similar to the fix implemented by Cryptography (https://github.com/pyca/cryptography/pull/2071/commits/666252ce9eb00b926437b49f17553097a8f813e9#diff-61af608275d527065eb127c6c04220dd), this will allow domains that contain a single leading wildcard(see RFC 2595) to be detected as a DNSName type.