### PR TITLE
Improve runtime dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,11 @@ Please see https://django-ca.readthedocs.org for more extensive documentation.
 """
 
 install_requires = [
-    'django>=2.2',
-    'asn1crypto>=1.0.1',
-    'cryptography>=2.8',
-    'django-object-actions>=1.1',
-    'idna>=2.9',
-    'packaging',
+    'django>=2.2,<3.2',
+    'asn1crypto>=1.0.1,<1.5',
+    'cryptography>=2.8,<3.4',
+    'django-object-actions>=1.1,<4',
+    'idna>=2.9,<4',
 ]
 
 package_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ca')


### PR DESCRIPTION
Dear Mathias,

in the light of #70 regarding problems with `cryptography==3.4`, I thought this patch wouldn't be a bad idea.

This is to be more conservative on the selection of dependencies that more recent releases of those don't make things go south.

With kind regards,
Andreas.

cc @truls
