### PR TITLE
[mDL] Added mDL extentions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ geckodriver.log
 /py2/
 /venv/
 /Makefile
+.idea/
+Pipfile*

--- a/ca/django_ca/extensions/extensions.py
+++ b/ca/django_ca/extensions/extensions.py
@@ -643,6 +643,7 @@ class ExtendedKeyUsage(
         "ipsecEndSystem": x509.ObjectIdentifier("1.3.6.1.5.5.7.3.5"),
         "ipsecTunnel": x509.ObjectIdentifier("1.3.6.1.5.5.7.3.6"),
         "ipsecUser": x509.ObjectIdentifier("1.3.6.1.5.5.7.3.7"),
+        "mdlDS": x509.ObjectIdentifier("1.0.18013.5.1.2"),
     }
     _CRYPTOGRAPHY_MAPPING_REVERSED = {v: k for k, v in CRYPTOGRAPHY_MAPPING.items()}
 
@@ -662,6 +663,7 @@ class ExtendedKeyUsage(
         ("ipsecEndSystem", "IPSec EndSystem"),
         ("ipsecTunnel", "IPSec Tunnel"),
         ("ipsecUser", "IPSec User"),
+        ("mdlDS", "mdlDS"),
         ("anyExtendedKeyUsage", "Any Extended Key Usage"),
     )
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,6 +18,7 @@ ChangeLog
 * Add support for cryptography 36.0.0.
 * Make log level and message format more easily configurable with :ref:`LOG_LEVEL <settings-log-level>`,
   :ref:`LIBRARY_LOG_LEVEL <settings-library-log-level>` and :ref:`LOG_FORMAT <settings-log-format>`.
+* Add X509 extension for support `mobile Driver Licence <https://en.wikipedia.org/wiki/Mobile_driver%27s_license>`_.
 
 ACMEv2 support
 ==============


### PR DESCRIPTION
Hello Mathias!

Currently I develop mDL CA  based on your awesome project, but I found that in the mDL documentation are using custom X.509 extentions.  According to the table **Table B.3 — mDL document signer certificate**

https://mobiledl-e5018.web.app/ISO_18013-5_E_draft.pdf

I need to have only one extended key

![image](https://user-images.githubusercontent.com/46032838/146897046-b9b349bc-0449-474b-b6f9-72230c7d2fd3.png)

Previously we tested this changes with my team, and this update works as well.

Hope I didn't lose something


![image](https://user-images.githubusercontent.com/46032838/146897563-8728c0fc-78c7-4e92-ad26-701f2c8363bc.png)

