### PR TITLE
Key backend refinements

### DIFF
--- a/ca/ca/test_settings.py
+++ b/ca/ca/test_settings.py
@@ -89,7 +89,15 @@ STORAGES = {
     "django-ca": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
         "OPTIONS": {
-            "location": "/does/not/exist/",
+            "location": "/does/not/exist/django-ca",
+            "file_permissions_mode": 0o600,
+            "directory_permissions_mode": 0o700,
+        },
+    },
+    "secondary": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "OPTIONS": {
+            "location": "/does/not/exist/secondary",
             "file_permissions_mode": 0o600,
             "directory_permissions_mode": 0o700,
         },
@@ -176,6 +184,18 @@ LOGGING = {
 # import situation.
 with open(BASE_DIR / "django_ca" / "tests" / "fixtures" / "cert-data.json", encoding="utf-8") as stream:
     _fixture_data = json.load(stream)
+
+
+CA_KEY_BACKENDS = {
+    "default": {
+        "BACKEND": "django_ca.key_backends.storages.StoragesBackend",
+        "OPTIONS": {"storage_alias": "django-ca"},
+    },
+    "secondary": {
+        "BACKEND": "django_ca.key_backends.storages.StoragesBackend",
+        "OPTIONS": {"storage_alias": "secondary"},
+    },
+}
 
 # Custom settings
 CA_DEFAULT_SUBJECT = (

--- a/ca/django_ca/forms.py
+++ b/ca/django_ca/forms.py
@@ -220,7 +220,7 @@ class CreateCertificateBaseForm(CertificateModelForm):
         )
 
         # Load the CA to test loading options
-        key_backend_options = ca.key_backend.get_use_private_key_options(data)
+        key_backend_options = ca.key_backend.get_use_private_key_options(ca, data)
         data["key_backend_options"] = key_backend_options
         if not ca.is_usable(key_backend_options):
             # TODO: this still assumes storages backend

--- a/ca/django_ca/key_backends/base.py
+++ b/ca/django_ca/key_backends/base.py
@@ -69,8 +69,19 @@ class KeyBackend(
     #: The Pydantic model representing the options used for loading a private key.
     use_model: Type[UsePrivateKeyOptionsTypeVar]
 
+    #: Prefix for argparse to use for arguments. Empty for the default alias, and `{alias}-` otherwise.
+    argparse_prefix: str = ""
+
+    #: Prefix to use for loading options. Empty for the default alias, and `{alias}_` otherwise.
+    options_prefix: str = ""
+
     def __init__(self, alias: str, **kwargs: Any) -> None:
         self.alias = alias
+
+        if self.alias != ca_settings.CA_DEFAULT_KEY_BACKEND:
+            self.argparse_prefix = f"{alias.lower().replace('_', '-')}-"
+            self.options_prefix = f"{alias.lower().replace('-', '_')}_"
+
         for key, value in kwargs.items():
             setattr(self, key, value)
 
@@ -84,7 +95,7 @@ class KeyBackend(
 
         Return ``None`` if you don't need to create such a group.
         """
-        return parser.add_argument_group(  # type: ignore[no-any-return]  # function is not typehinted
+        return parser.add_argument_group(  # type: ignore[no-any-return]  # function is not type-hinted
             f"{self.alias}: {self.title}",
             f"The backend used with --key-backend={self.alias}. {self.description}",
         )
@@ -106,7 +117,7 @@ class KeyBackend(
 
         Return ``None`` if you don't need to create such a group.
         """
-        return parser.add_argument_group(  # type: ignore[no-any-return]  # function is not typehinted
+        return parser.add_argument_group(  # type: ignore[no-any-return]  # function is not type-hinted
             f"{self.alias} key storage",
             f"Arguments for using private keys stored with the {self.alias} backend.",
         )

--- a/ca/django_ca/key_backends/base.py
+++ b/ca/django_ca/key_backends/base.py
@@ -156,27 +156,39 @@ class KeyBackend(
     def get_create_private_key_options(
         self, key_type: ParsableKeyType, options: Dict[str, Any]
     ) -> CreatePrivateKeyOptionsTypeVar:
-        """Load options to create private keys into a Pydantic model.
+        """Get options to create private keys into a Pydantic model.
 
-        `options` is the dictionary of arguments to ``manage.py init_ca`` (including default values). The
-        returned model will be passed to
+        `options` is the dictionary of arguments from :command:`manage.py init_ca` (including default values).
+        The returned model will be passed to
         :py:func:`~django_ca.key_backends.base.KeyBackend.create_private_key`.
         """
 
     @abc.abstractmethod
-    def get_use_parent_private_key_options(self, options: Dict[str, Any]) -> UsePrivateKeyOptionsTypeVar:
-        """Get options to create private keys into a Pydantic model.
+    def get_use_parent_private_key_options(
+        self, ca: "CertificateAuthority", options: Dict[str, Any]
+    ) -> UsePrivateKeyOptionsTypeVar:
+        """Get options to use the private key of a parent certificate authority.
 
-        `options` is the dictionary of arguments to ``manage.py init_ca`` (including default values). The key
-        backend is expected to be able to sign certificate authorities using the options provided here.
+        The returned model will be used for the certificate authority `ca`. You can pass it as extra context
+        to influence model validation.
+
+        `options` is the dictionary of arguments to :command:`manage.py init_ca` (including default values).
+        The key backend is expected to be able to sign certificate authorities using the options provided
+        here.
         """
 
     @abc.abstractmethod
-    def get_use_private_key_options(self, options: Dict[str, Any]) -> UsePrivateKeyOptionsTypeVar:
-        """Get options to create private keys into a Pydantic model.
+    def get_use_private_key_options(
+        self, ca: Optional["CertificateAuthority"], options: Dict[str, Any]
+    ) -> UsePrivateKeyOptionsTypeVar:
+        """Get options to use the private key of a certificate authority.
 
-        `options` is the dictionary of arguments to ``manage.py init_ca`` (including default values). The key
-        backend is expected to be able to sign certificates and CRLs using the options provided here.
+        The returned model will be used for the certificate authority `ca`. You can pass it as extra context
+        to influence model validation. If `ca` is ``None``, it indicates that the CA is currently being
+        created via :command:`manage.py init_ca`.
+
+        `options` is the dictionary of arguments to :command:`manage.py init_ca` (including default values).
+        The key backend is expected to be able to sign certificates and CRLs using the options provided here.
         """
 
     @abc.abstractmethod

--- a/ca/django_ca/key_backends/storages.py
+++ b/ca/django_ca/key_backends/storages.py
@@ -266,20 +266,20 @@ class StoragesBackend(KeyBackend[CreatePrivateKeyOptions, StorePrivateKeyOptions
         ca.key_backend_options = {"path": path}
 
     def get_key(
-        self, ca: "CertificateAuthority", load_options: UsePrivateKeyOptions
+        self, ca: "CertificateAuthority", use_private_key_options: UsePrivateKeyOptions
     ) -> CertificateIssuerPrivateKeyTypes:
         """The CAs private key as private key."""
         storage = storages[self.storage_alias]
         path = ca.key_backend_options["path"]
 
-        # Load private key data
+        # Load encoded private key data from the filesystem
         stream = storage.open(path, mode="rb")
         try:
             key_data: bytes = stream.read()
         finally:
             stream.close()
 
-        password = load_options.password
+        password = use_private_key_options.password
 
         try:
             key = typing.cast(  # type validated below

--- a/ca/django_ca/management/base.py
+++ b/ca/django_ca/management/base.py
@@ -53,25 +53,20 @@ if typing.TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise
 
 
-def add_elliptic_curve(parser: ActionsContainer) -> None:
+def add_elliptic_curve(parser: ActionsContainer, prefix: str = "") -> None:
     """Add --elliptic-curve option."""
     default = ca_settings.CA_DEFAULT_ELLIPTIC_CURVE.name
     parser.add_argument(
-        "--elliptic-curve",
+        f"--{prefix}elliptic-curve",
         action=actions.EllipticCurveAction,
         help=f"Elliptic Curve used for EC keys (default: {default}).",
     )
 
 
-def add_password(parser: ActionsContainer, help_text: str = "") -> None:
-    """Add a password option."""
-    parser.add_argument("-p", "--password", nargs="?", action=actions.PasswordAction, help=help_text)
-
-
-def add_key_size(parser: ActionsContainer) -> None:
+def add_key_size(parser: ActionsContainer, prefix: str = "") -> None:
     """Add --key-size option (2048, 4096, ...)."""
     parser.add_argument(
-        "--key-size",
+        f"--{prefix}key-size",
         action=actions.KeySizeAction,
         help=f"Key size for a RSA/DSA private key (default: {ca_settings.CA_DEFAULT_KEY_SIZE}).",
     )

--- a/ca/django_ca/management/commands/dump_crl.py
+++ b/ca/django_ca/management/commands/dump_crl.py
@@ -91,7 +91,7 @@ class Command(UsePrivateKeyMixin, BinaryCommand):
                 "Cannot add IssuingDistributionPoint extension to CRLs with no scope for root CAs."
             )
 
-        key_backend_options = ca.key_backend.get_use_private_key_options(options)
+        key_backend_options = ca.key_backend.get_use_private_key_options(ca, options)
 
         # Actually create the CRL
         try:

--- a/ca/django_ca/management/commands/init_ca.py
+++ b/ca/django_ca/management/commands/init_ca.py
@@ -306,7 +306,7 @@ class Command(StorePrivateKeyMixin, CertificateAuthorityDetailMixin, BaseSignCom
     ) -> None:
         try:
             key_backend_options = key_backend.get_create_private_key_options(key_type, options)
-            load_key_backend_options = key_backend.get_use_private_key_options(options)
+            load_key_backend_options = key_backend.get_use_private_key_options(None, options)
 
             # If there is a parent CA, test if we can use it (here) to sign certificates. The most common case
             # where this happens is if the key is stored on the filesystem, but only accessible to the Celery
@@ -314,7 +314,9 @@ class Command(StorePrivateKeyMixin, CertificateAuthorityDetailMixin, BaseSignCom
             if parent is None:
                 signer_key_backend_options = load_key_backend_options
             else:
-                signer_key_backend_options = parent.key_backend.get_use_parent_private_key_options(options)
+                signer_key_backend_options = parent.key_backend.get_use_parent_private_key_options(
+                    parent, options
+                )
                 if parent.is_usable(signer_key_backend_options) is False:
                     raise CommandError("Parent CA is not usable.")
         except Exception as ex:

--- a/ca/django_ca/management/commands/regenerate_ocsp_keys.py
+++ b/ca/django_ca/management/commands/regenerate_ocsp_keys.py
@@ -107,7 +107,7 @@ class Command(UsePrivateKeyMixin, BaseCommand):
                 self.stderr.write(self.style.ERROR(f"{hr_serial}: Unknown CA."))
                 continue
 
-            key_backend_options = ca.key_backend.get_use_private_key_options(options)
+            key_backend_options = ca.key_backend.get_use_private_key_options(ca, options)
             if not ca.is_usable(key_backend_options):
                 if quiet is False:  # pragma: no branch
                     # NOTE: coverage falsely identifies the above condition to always be false.

--- a/ca/django_ca/management/commands/resign_cert.py
+++ b/ca/django_ca/management/commands/resign_cert.py
@@ -108,7 +108,7 @@ default profile, currently {ca_settings.CA_DEFAULT_PROFILE}."""
         self.test_options(ca=ca, expires=expires, profile=profile_obj, **options)
 
         # Get key backend options
-        key_backend_options = ca.key_backend.get_use_private_key_options(options)
+        key_backend_options = ca.key_backend.get_use_private_key_options(ca, options)
 
         # Get/validate signature hash algorithm
         algorithm = self.get_hash_algorithm(ca.key_type, algorithm, ca.algorithm)

--- a/ca/django_ca/management/commands/sign_cert.py
+++ b/ca/django_ca/management/commands/sign_cert.py
@@ -114,7 +114,7 @@ https://django-ca.readthedocs.io/en/latest/extensions.html for more information.
             raise CommandError("Certificate Authority is revoked.")
 
         # Get key backend options
-        key_backend_options = ca.key_backend.get_use_private_key_options(options)
+        key_backend_options = ca.key_backend.get_use_private_key_options(ca, options)
 
         # Get/validate signature hash algorithm
         algorithm = self.get_hash_algorithm(ca.key_type, algorithm, ca.algorithm)

--- a/ca/django_ca/models.py
+++ b/ca/django_ca/models.py
@@ -603,7 +603,7 @@ class CertificateAuthority(X509CertMixin):
     def key_backend(self) -> KeyBackend[BaseModel, BaseModel, BaseModel]:
         """The key backend that can be used to use the private key."""
         if self._key_backend is None:
-            self._key_backend = key_backends[ca_settings.CA_DEFAULT_KEY_BACKEND]
+            self._key_backend = key_backends[self.key_backend_alias]
         return self._key_backend
 
     def is_usable(self, options: Optional[BaseModel] = None) -> bool:

--- a/ca/django_ca/tasks.py
+++ b/ca/django_ca/tasks.py
@@ -199,7 +199,7 @@ def sign_certificate(
         subject=subject,
     )
 
-    key_backend_options = ca.key_backend.get_use_private_key_options({})
+    key_backend_options = ca.key_backend.get_use_private_key_options(ca, {})
 
     parsed_extensions = message.get_extensions()
 
@@ -390,7 +390,7 @@ def acme_issue_certificate(acme_certificate_pk: int) -> None:
     csr = acme_cert.parse_csr()
 
     # Initialize key backend options
-    key_backend_options = ca.key_backend.get_use_private_key_options({})
+    key_backend_options = ca.key_backend.get_use_private_key_options(ca, {})
 
     # Finally, actually create a certificate
     cert = Certificate.objects.create_cert(

--- a/ca/django_ca/tests/commands/test_import_ca.py
+++ b/ca/django_ca/tests/commands/test_import_ca.py
@@ -270,7 +270,7 @@ def test_secondary_key_backend(ca_name: str) -> None:
     assert ca.key_backend_alias == "secondary"
     assert ca.key_backend_options["path"].startswith("secondary-ca-path")
     assert isinstance(ca.key_backend, StoragesBackend)
-    assert ca.key_backend.get_key(ca, UsePrivateKeyOptions(password="foobar"))
+    assert ca.key_backend.get_key(ca, UsePrivateKeyOptions(password="foobar"))  # type: ignore[attr-defined]
 
 
 def test_bogus_public_key(ca_name: str) -> None:

--- a/ca/django_ca/tests/key_backends/test_base.py
+++ b/ca/django_ca/tests/key_backends/test_base.py
@@ -135,7 +135,7 @@ def test_key_backends_getitem_with_invalid_backend() -> None:
 
 def test_key_backends_iter(settings: SettingsWrapper) -> None:
     """Test dict-style lookup ."""
-    assert list(key_backends) == [key_backends[ca_settings.CA_DEFAULT_KEY_BACKEND]]
+    assert list(key_backends) == [key_backends[ca_settings.CA_DEFAULT_KEY_BACKEND], key_backends["secondary"]]
 
     settings.CA_KEY_BACKENDS = {
         ca_settings.CA_DEFAULT_KEY_BACKEND: {

--- a/ca/django_ca/tests/key_backends/test_base.py
+++ b/ca/django_ca/tests/key_backends/test_base.py
@@ -61,7 +61,9 @@ class DummyBackend(KeyBackend[DummyModel, DummyModel, DummyModel]):
     def add_use_parent_private_key_arguments(self, group: ArgumentGroup) -> None:
         return None
 
-    def get_use_parent_private_key_options(self, options: Dict[str, Any]) -> DummyModel:
+    def get_use_parent_private_key_options(
+        self, ca: CertificateAuthority, options: Dict[str, Any]
+    ) -> DummyModel:
         return DummyModel()
 
     def get_store_private_key_options(self, options: Dict[str, Any]) -> DummyModel:
@@ -72,7 +74,9 @@ class DummyBackend(KeyBackend[DummyModel, DummyModel, DummyModel]):
     ) -> Tuple[CertificateIssuerPublicKeyTypes, DummyModel]:
         return None, DummyModel()  # type: ignore[return-value]
 
-    def get_use_private_key_options(self, options: Dict[str, Any]) -> DummyModel:
+    def get_use_private_key_options(
+        self, ca: Optional[CertificateAuthority], options: Dict[str, Any]
+    ) -> DummyModel:
         return DummyModel()
 
     def is_usable(

--- a/ca/django_ca/tests/test_utils.py
+++ b/ca/django_ca/tests/test_utils.py
@@ -76,11 +76,10 @@ def test_doctests() -> None:
     assert failures == 0, f"{failures} doctests failed, see above for output."
 
 
-@pytest.mark.usefixtures("tmpcadir")
-def test_read_file(tmp_path: Path) -> None:
+def test_read_file(tmpcadir: Path) -> None:
     """Test :py:func:`django_ca.utils.read_file`."""
     name = "test-data"
-    path = os.path.join(tmp_path, name)
+    path = os.path.join(tmpcadir, name)
     data = b"test data"
     with open(path, "wb") as stream:
         stream.write(data)

--- a/ca/django_ca/views.py
+++ b/ca/django_ca/views.py
@@ -98,7 +98,7 @@ class CertificateRevocationListView(View, SingleObjectMixinBase):
         If a custom CA backend needs transient parameters (e.g. passwords), a view overriding this method
         must be implemented.
         """
-        return ca.key_backend.get_use_private_key_options({"password": self.password})
+        return ca.key_backend.get_use_private_key_options(ca, {"password": self.password})
 
     def get(self, request: HttpRequest, serial: str) -> HttpResponse:
         # pylint: disable=missing-function-docstring; standard Django view function

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,8 +19,9 @@ ChangeLog
 * ``pydantic>=2.5`` is now a required dependency.
 * Preparations for support for using Hardware Security Modules, "Key backend support" below.
 * The ``CA_FILE_STORAGE`` and ``CA_FILE_STORAGE_KWARGS`` settings are deprecated in favor of
-  :ref:`settings-ca-key-backends`. Installations :doc:`as Django app <quickstart_as_app>` must add a
-  ``"django-ca"`` storage alias in their configuration.
+  :ref:`settings-ca-key-backends` and will be removed in ``django-ca==2.0``. Installations :doc:`as Django
+  app <quickstart_as_app>` must add a ``"django-ca"`` storage alias in their configuration.
+* The :ref:`settings-ca-passwords` setting is now consistently used whenever required.
 * Private keys (for CAs and OCSP responder certificates) are now stored as DER keys to improve loading speed.
 * The admin interface now presents lists of general names (e.g. in the Subject Alternative Name extension) as
   a list of order-able key/value pairs when adding certificates.
@@ -84,6 +85,8 @@ Deprecation notices
 * Support for OpenSSL-style subjects will be removed in django-ca 2.2.
 * ``django_ca.extensions.parse_extension()`` is deprecated and should not longer be used. Use Pydantic models
   instead.
+* The ``CA_FILE_STORAGE`` and ``CA_FILE_STORAGE_KWARGS`` settings are deprecated in favor of
+  :ref:`settings-ca-key-backends` and will be removed in ``django-ca==2.0``.
 
 .. _changelog-1.27.0:
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -79,7 +79,7 @@ Backwards incompatible changes
 Deprecation notices
 ===================
 
-* This is the last release to support Python 3.8.
+* This is the last release to support Python 3.8, ``cryptography~=41.0``, ``acme~=2.7.0`` and ``acme~=2.8.0``.
 * The default subject format will switch from OpenSSL-style to RFC 4514 in django-ca 2.0.
 * Support for OpenSSL-style subjects will be removed in django-ca 2.2.
 * ``django_ca.extensions.parse_extension()`` is deprecated and should not longer be used. Use Pydantic models

--- a/docs/source/django_ca_sphinx/console_include.py
+++ b/docs/source/django_ca_sphinx/console_include.py
@@ -20,6 +20,7 @@ import typing
 import jinja2
 import yaml
 from docutils.parsers.rst import directives
+from docutils.statemachine import StringList
 from sphinx.directives.code import CodeBlock  # code-block directive from Sphinx
 from sphinx.util.typing import OptionSpec
 
@@ -175,7 +176,7 @@ class ConsoleIncludeDirective(CodeBlock):
         return lines
 
     @property
-    def content(self) -> typing.List[str]:
+    def content(self) -> StringList:
         """Actually render the template."""
         include = self.options.get("include")
         if not include:
@@ -223,7 +224,7 @@ class ConsoleIncludeDirective(CodeBlock):
             if "display_output" in config:
                 lines += self._render_template(config["display_output"], context).splitlines()
 
-        return lines
+        return StringList(lines)
 
     @content.setter
     def content(self, value: typing.Any) -> None:

--- a/docs/source/django_ca_sphinx/template_include.py
+++ b/docs/source/django_ca_sphinx/template_include.py
@@ -16,6 +16,7 @@
 import typing
 
 from docutils.parsers.rst import directives
+from docutils.statemachine import StringList
 from jinja2 import Environment, FileSystemLoader
 from sphinx.directives.code import CodeBlock  # code-block directive from Sphinx
 from sphinx.util.typing import OptionSpec
@@ -59,7 +60,7 @@ class TemplateDirective(CodeBlock):
         self.jinja_env.policies.update(self.config.jinja_policies)  # type: ignore[attr-defined]
 
     @property
-    def content(self) -> typing.List[str]:
+    def content(self) -> StringList:
         """Actually render the template."""
         template = self.jinja_env.get_template(self.arguments[1])
         context_name = self.options.get("context")
@@ -73,7 +74,7 @@ class TemplateDirective(CodeBlock):
             context = self.config.jinja_contexts[context_name].copy()
 
         content = template.render(**context)
-        return content.splitlines()
+        return StringList(content.splitlines())
 
     @content.setter
     def content(self, value: typing.Any) -> None:

--- a/docs/source/python/key_backends.rst
+++ b/docs/source/python/key_backends.rst
@@ -15,7 +15,7 @@ Supported key backends
 Writing custom backends
 ***********************
 
-.. INFO:: The key backend interface is new and might change in future versions without notice.
+.. warning:: The key backend interface is new and might change in future versions without notice.
 
 Writing a custom key backend allows you to store keys in a custom way, e.g. in a custom Hardware Security
 Module (HSM) or using a different library that handles some kind of file storage or dedicated private key

--- a/docs/source/python/key_backends.rst
+++ b/docs/source/python/key_backends.rst
@@ -15,6 +15,8 @@ Supported key backends
 Writing custom backends
 ***********************
 
+.. INFO:: The key backend interface is new and might change in future versions without notice.
+
 Writing a custom key backend allows you to store keys in a custom way, e.g. in a custom Hardware Security
 Module (HSM) or using a different library that handles some kind of file storage or dedicated private key
 storage. Writing such a key backend will require some skills though. You should know at least:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,7 @@ max-locals = 20
 max-parents = 15
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods = 25
+max-public-methods = 30
 
 [tool.pylint.format]
 max-line-length = 110
@@ -400,7 +400,8 @@ filterwarnings = [
     #"error:datetime.datetime.utcfromtimestamp\\(\\) is deprecated::django_ca",  # pragma: only cg<42
     "error:datetime.datetime.utcnow\\(\\) is deprecated::django_ca",
 
-    "ignore:django.core.files.storage.get_storage_class is deprecated::django",  # pragma: only django<4.2
+    # pragma: only django<4.2  # Will have to get rid of this functionality with django 5.1.
+    "ignore:django.core.files.storage.get_storage_class is deprecated",
 
     # pytest-freezegun==0.4.2 issues this (harmless for now) warning:
     "ignore:distutils Version classes are deprecated. Use packaging.version instead.::pytest_freezegun",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -391,27 +391,22 @@ filterwarnings = [
     "error:::cryptography",
     "error:::acme",
     "error:::josepy",
-    # utcnow() and utcfromtimestamp() are deprecated in Python 3.12. django-ca no longer uses either, but
-    # various third-party software still does, so we silence the warnings outside of django-ca.
-    "ignore:datetime.datetime.utcfromtimestamp\\(\\) is deprecated",
-    "ignore:datetime.datetime.utcnow\\(\\) is deprecated",
+    "error:::pydantic",
+
     # Disabled because cryptography calls the function directly and the warning is issued with stacklevel=2,
     # so it's shown for our code. See: https://github.com/pyca/cryptography/issues/9580
-    #"error:datetime.datetime.utcfromtimestamp\\(\\) is deprecated::django_ca",  # pragma: only cg<42
-    "error:datetime.datetime.utcnow\\(\\) is deprecated::django_ca",
+    "ignore:datetime.datetime.utcfromtimestamp\\(\\) is deprecated::django_ca",  # pragma: only cg<42
 
-    # pragma: only django<4.2  # Will have to get rid of this functionality with django 5.1.
-    "ignore:django.core.files.storage.get_storage_class is deprecated",
-
-    # pytest-freezegun==0.4.2 issues this (harmless for now) warning:
-    "ignore:distutils Version classes are deprecated. Use packaging.version instead.::pytest_freezegun",
+    # Will have to get rid of this functionality with django 5.1.
+    "ignore:django.core.files.storage.get_storage_class is deprecated",  # pragma: only django<4.2
 
     # pyOpenSSL>=23.3.0 raises this warning, acme==2.7.3 still uses the deprecated APIs.
     # acme uses X509Extension in acme.crypto_util.gen_ss_cert(). See also:
     #   https://github.com/certbot/certbot/issues/9828
     "ignore:^X509Extension support in pyOpenSSL is deprecated\\. You should use the APIs in cryptography\\.$::acme",
 
-    # django-ninja still uses class-based configuration, deprecated in Pydantic 2.0
+    # django-ninja==1.1.0 still uses class-based configuration, deprecated in Pydantic 2.0
+    #   https://github.com/vitalik/django-ninja/issues/1093
     "ignore:^Support for class-based `config` is deprecated, use ConfigDict instead.::pydantic",
 ]
 

--- a/requirements/requirements-dev-common.txt
+++ b/requirements/requirements-dev-common.txt
@@ -4,7 +4,7 @@ Jinja2==3.1.3
 PyYAML==6.0.1
 Sphinx==7.2.6; python_version > '3.8'
 Sphinx~=7.1; python_version == '3.8'
-coverage[toml]==7.4.3
+coverage[toml]==7.4.4
 pytest==8.1.1
 pytest-cov==4.1.0
 pytest-django==4.8.0

--- a/requirements/requirements-dist.txt
+++ b/requirements/requirements-dist.txt
@@ -1,5 +1,5 @@
 build==1.1.1
 twine==5.0.0
-wheel==0.42.0
+wheel==0.43.0
 # See pyproject.toml for reasoning for required minimum version
 setuptools>=68.1

--- a/requirements/requirements-lint.txt
+++ b/requirements/requirements-lint.txt
@@ -2,5 +2,5 @@
 pre-commit==3.6.2
 pylint-django==2.5.5
 pylint==3.1.0
-ruff==0.3.2
+ruff==0.3.3
 setuptools>=65

--- a/requirements/requirements-mypy.txt
+++ b/requirements/requirements-mypy.txt
@@ -2,14 +2,14 @@
 -r requirements-test.txt
 mypy==1.9.0
 django-stubs==4.2.7
-types-docutils==0.20.0.20240310
+types-docutils==0.20.0.20240316
 types-freezegun==1.1.10
 types-jinja2==2.11.9
-types-mysqlclient==2.2.0.1
-types-psycopg2==2.9.21.20240218
-types-pyOpenSSL==24.0.0.20240228
+types-mysqlclient==2.2.0.20240311
+types-psycopg2==2.9.21.20240311
+types-pyOpenSSL==24.0.0.20240311
 types-pyRFC3339==1.1.1.5
-types-redis==4.6.0.20240218
-types-requests==2.31.0.20240310
-types-setuptools==69.1.0.20240310
+types-redis==4.6.0.20240311
+types-requests==2.31.0.20240311
+types-setuptools==69.2.0.20240316
 types-tabulate==0.9.0.20240106

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -5,6 +5,6 @@ freezegun==1.4.0
 pyOpenSSL>=23
 pyrfc3339==1.1
 pytest-env==1.1.3
-pytest-freezegun==0.4.2
+pytest-freezer==0.4.8
 pytest-random-order==1.1.1
 requests-mock==1.11.0


### PR DESCRIPTION
Key backends:

* Add support for multiple configured storages backends.
* Pass the CA when loading parent model for parent private keys and for using private keys. This means that `settings.CA_PASSWORDS` is now honored in `init_ca` and a few other places where it wasn't before.
* Bugfix: get the right key backend when loading it via the model instance.

Other changes:
* minor dep update
* cleanup warnings filters in pytest
* switch to python-freezer (see ktosiek/pytest-freezegun#44)