### PR TITLE
Add HSM support via pkcs11

### DIFF
--- a/.github/workflows/faketime.yml
+++ b/.github/workflows/faketime.yml
@@ -10,7 +10,7 @@ jobs:
     name: libfaketime test
     steps:
       - name: Install APT dependencies
-        run: sudo apt-get install -y firefox faketime
+        run: sudo apt-get install -y firefox softhsm2 faketime
 
       - name: Acquire sources
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     name: Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}, cryptography ${{ matrix.cryptography-version }}, pydantic ${{ matrix.pydantic-version }}
     steps:
       - name: Install APT dependencies
-        run: sudo apt-get install -y firefox
+        run: sudo apt-get install -y firefox softhsm2
 
       - name: Acquire sources
         uses: actions/checkout@v4.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/root/.cache/pip/http \
     pip install --no-warn-script-location --ignore-installed --prefix=/install \
         -r requirements/requirements-docker.txt \
         -r requirements-pinned.txt \
-        -e .[celery,redis,mysql,psycopg3,yaml]
+        -e .[celery,hsm,mysql,psycopg3,redis,yaml]
 
 # Finally, copy sources
 COPY ca/ ca/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Documentation is available at https://django-ca.readthedocs.org/.
 1. Set up a secure local certificate authority in just a few minutes.
 2. Certificate revocation via CRLs and OCSP.
 3. Certificate issuance via ACMEv2, command line or web interface.
+4. **Preliminary** support for hardware security modules (HSMs).
 4. Management via command line and/or via Django's admin interface.
 5. Get email notifications about certificates about to expire.
 6. Written in Python 3.9+, Django 4.2+ and cryptography 42+.

--- a/ca/django_ca/constants.py
+++ b/ca/django_ca/constants.py
@@ -574,6 +574,18 @@ PUBLIC_KEY_TYPES: tuple[type[CertificateIssuerPublicKeyTypes], ...] = (
     ed448.Ed448PublicKey,
     rsa.RSAPublicKey,
 )
+PUBLIC_KEY_TYPE_MAPPING: MappingProxyType[ParsableKeyType, type[CertificateIssuerPublicKeyTypes]] = (
+    MappingProxyType(
+        {
+            "DSA": dsa.DSAPublicKey,
+            "EC": ec.EllipticCurvePublicKey,
+            "Ed25519": ed25519.Ed25519PublicKey,
+            "Ed448": ed448.Ed448PublicKey,
+            "RSA": rsa.RSAPublicKey,
+        }
+    )
+)
+
 
 #: Tuple of supported private key types.
 PRIVATE_KEY_TYPES: tuple[type[CertificateIssuerPrivateKeyTypes], ...] = (

--- a/ca/django_ca/key_backends/base.py
+++ b/ca/django_ca/key_backends/base.py
@@ -225,13 +225,12 @@ class KeyBackend(
 
     @abc.abstractmethod
     def get_use_private_key_options(
-        self, ca: Optional["CertificateAuthority"], options: dict[str, Any]
+        self, ca: "CertificateAuthority", options: dict[str, Any]
     ) -> UsePrivateKeyOptionsTypeVar:
         """Get options to use the private key of a certificate authority.
 
         The returned model will be used for the certificate authority `ca`. You can pass it as extra context
-        to influence model validation. If `ca` is ``None``, it indicates that the CA is currently being
-        created via :command:`manage.py init_ca`.
+        to influence model validation.
 
         `options` is the dictionary of arguments to :command:`manage.py init_ca` (including default values).
         The key backend is expected to be able to sign certificates and CRLs using the options provided here.
@@ -285,6 +284,7 @@ class KeyBackend(
         self,
         ca: "CertificateAuthority",
         key: CertificateIssuerPrivateKeyTypes,
+        certificate: x509.Certificate,
         options: StorePrivateKeyOptionsTypeVar,
     ) -> None:
         """Store a private key for the certificate authority.

--- a/ca/django_ca/key_backends/hsm/__init__.py
+++ b/ca/django_ca/key_backends/hsm/__init__.py
@@ -1,0 +1,18 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""HSM backend module."""
+
+from django_ca.key_backends.hsm.backend import HSMBackend
+
+__all__ = ("HSMBackend",)

--- a/ca/django_ca/key_backends/hsm/backend.py
+++ b/ca/django_ca/key_backends/hsm/backend.py
@@ -1,0 +1,488 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Key storage backend for hardware security modules (HSMs)."""
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Final, Optional
+
+import pkcs11
+from pkcs11 import KeyType, ObjectClass, Session
+from pkcs11.util.ec import decode_ec_private_key, decode_ec_public_key, encode_named_curve_parameters
+from pkcs11.util.rsa import decode_rsa_private_key, decode_rsa_public_key
+
+from asn1crypto.algos import SignedDigestAlgorithmId
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
+from cryptography.hazmat.primitives.asymmetric.types import (
+    CertificateIssuerPrivateKeyTypes,
+    CertificateIssuerPublicKeyTypes,
+)
+
+from django.core.management import CommandError
+
+from django_ca import constants
+from django_ca.conf import model_settings
+from django_ca.key_backends import KeyBackend
+from django_ca.key_backends.hsm.keys import (
+    PKCS11Ed448PrivateKey,
+    PKCS11Ed25519PrivateKey,
+    PKCS11EllipticCurvePrivateKey,
+    PKCS11PrivateKeyTypes,
+    PKCS11RSAPrivateKey,
+)
+from django_ca.key_backends.hsm.models import (
+    CreatePrivateKeyOptions,
+    HSMBackendStorePrivateKeyOptions,
+    HSMBackendUsePrivateKeyOptions,
+)
+from django_ca.key_backends.hsm.session import SessionPool
+from django_ca.key_backends.hsm.typehints import SupportedKeyType
+from django_ca.typehints import (
+    AllowedHashTypes,
+    ArgumentGroup,
+    CertificateExtension,
+    EllipticCurves,
+    HashAlgorithms,
+    ParsableKeyType,
+)
+from django_ca.utils import get_cert_builder, int_to_hex
+
+if TYPE_CHECKING:
+    from django_ca.models import CertificateAuthority
+
+
+class HSMBackend(
+    KeyBackend[CreatePrivateKeyOptions, HSMBackendStorePrivateKeyOptions, HSMBackendUsePrivateKeyOptions]
+):
+    """A key backend to create and use private keys in a hardware security module (HSM)."""
+
+    name = "hsm"
+    title = "Store private keys using a hardware security module (HSM)"
+    description = (
+        "The private key will be stored on the hardware security module (HSM). The HSM makes sure that the"
+        "private key can never be recovered and thus compromised."
+    )
+    use_model = HSMBackendUsePrivateKeyOptions
+
+    supported_key_types: tuple[SupportedKeyType, ...] = ("RSA", "EC", "Ed25519", "Ed448")
+    supported_hash_algorithms: tuple[HashAlgorithms, ...] = ("SHA-224", "SHA-256", "SHA-384", "SHA-512")
+    supported_elliptic_curves: tuple[EllipticCurves, ...] = tuple(constants.ELLIPTIC_CURVE_TYPES)
+
+    library_path: str
+    token: str
+    so_pin: Optional[str]
+    user_pin: Optional[str]
+    _required_key_backend_options: Final[tuple[str, str, str]] = ("key_label", "key_id", "key_type")
+
+    def __init__(
+        self,
+        alias: str,
+        library_path: str,
+        token: str,
+        so_pin: Optional[str] = None,
+        user_pin: Optional[str] = None,
+    ):
+        if so_pin is not None and user_pin is not None:
+            raise ValueError(f"{alias}: Set either so_pin or user_pin.")
+
+        super().__init__(alias, library_path=library_path, token=token, so_pin=so_pin, user_pin=user_pin)
+
+    @contextmanager
+    def session(self, so_pin: Optional[str], user_pin: Optional[str], rw: bool = False) -> Iterator[Session]:
+        """Shortcut to get a session from the pool."""
+        try:
+            with SessionPool(self.library_path, self.token, so_pin, user_pin, rw=rw) as session:
+                yield session
+        # python-pkcs11 provides no useful exception strings, so we re-create exceptions with useful ones that
+        # can be sent to the user.
+        except pkcs11.UserNotLoggedIn as ex:
+            # NOTE: We always authenticate, but some operations are known to require a pin and the underlying
+            # pkcs11 library does not support it. The known case is creating a key with a SO pin.
+            raise pkcs11.UserNotLoggedIn(
+                "An operation required a login, but none was provided. This is most likely a bug in the "
+                "underlying library, not in django-ca."
+            ) from ex
+        except pkcs11.PinIncorrect as ex:
+            raise pkcs11.PinIncorrect("Pin incorrect.") from ex  # user supplied incorrect pin
+        except pkcs11.NoSuchToken as ex:
+            raise pkcs11.NoSuchToken(f"{self.token}: Token not found.") from ex
+        except pkcs11.SessionReadOnly as ex:
+            # E.g. trying to generate a key with a read-only session. Should not happen.
+            raise pkcs11.SessionReadOnly("Attempting to write to a read-only session.") from ex
+        except pkcs11.PKCS11Error as ex:
+            # Catch-all for any PKCS11 error. Should not happen, as all relevant errors are handled above.
+            raise pkcs11.PKCS11Error(f"Unknown pkcs11 error ({type(ex).__name__}).") from ex
+
+    def _add_key_label_argument(self, group: ArgumentGroup, prefix: str = "") -> None:
+        group.add_argument(
+            f"--{self.argparse_prefix}{prefix}key-label",
+            type=str,
+            metavar="LABEL",
+            help="%(metavar)s to use for the private key in the HSM.",
+        )
+
+    def _add_pin_arguments(self, group: ArgumentGroup, prefix: str = "") -> None:
+        group.add_argument(
+            f"--{self.argparse_prefix}{prefix}so-pin",
+            type=str,
+            metavar="PIN",
+            help="Security officer %(metavar)s to access the HSM.",
+        )
+        group.add_argument(
+            f"--{self.argparse_prefix}{prefix}user-pin",
+            type=str,
+            metavar="PIN",
+            help="User %(metavar)s to access the HSM.",
+        )
+
+    def _get_pins(self, options: dict[str, Any], prefix: str = "") -> tuple[Optional[str], Optional[str]]:
+        options_prefix = f"{self.options_prefix}{prefix.replace('-', '_')}"
+        argparse_prefix = f"{self.argparse_prefix}{prefix}"
+
+        so_pin: Optional[str] = options.get(f"{options_prefix}so_pin")
+        if so_pin is None:
+            so_pin = self.so_pin
+        elif so_pin == "":
+            so_pin = None
+
+        user_pin: Optional[str] = options.get(f"{options_prefix}user_pin")
+        if user_pin is None:
+            user_pin = self.user_pin
+        elif user_pin == "":
+            user_pin = None
+
+        if so_pin is not None and user_pin is not None:
+            raise CommandError(
+                "Both SO pin and user pin configured. To override a pin from settings, pass "
+                f'--{argparse_prefix}so-pin="" or --{argparse_prefix}user-pin="".'
+            )
+
+        return so_pin, user_pin
+
+    def _get_private_key(self, ca: "CertificateAuthority", session: Session) -> PKCS11PrivateKeyTypes:
+        key_id: str = ca.key_backend_options["key_id"]
+        key_label: str = ca.key_backend_options["key_label"]
+        key_type: SupportedKeyType = ca.key_backend_options["key_type"]
+
+        if key_type == "RSA":
+            return PKCS11RSAPrivateKey(session, key_id, key_label)
+        if key_type == "Ed448":
+            return PKCS11Ed448PrivateKey(session, key_id, key_label)
+        if key_type == "Ed25519":
+            return PKCS11Ed25519PrivateKey(session, key_id, key_label)
+        if key_type == "EC":
+            return PKCS11EllipticCurvePrivateKey(session, key_id, key_label)
+
+        raise ValueError(f"{key_type}: Unsupported key type.")
+
+    def add_create_private_key_arguments(self, group: ArgumentGroup) -> None:
+        self._add_key_label_argument(group)
+        self._add_pin_arguments(group)
+
+    def add_use_parent_private_key_arguments(self, group: ArgumentGroup) -> None:
+        self._add_pin_arguments(group, "parent-")
+
+    def add_store_private_key_arguments(self, group: ArgumentGroup) -> None:
+        self._add_key_label_argument(group)
+        self._add_pin_arguments(group)
+
+    def add_use_private_key_arguments(self, group: ArgumentGroup) -> None:
+        self._add_pin_arguments(group)
+
+    def get_create_private_key_options(
+        self,
+        key_type: ParsableKeyType,
+        key_size: Optional[int],
+        elliptic_curve: Optional[str],
+        options: dict[str, Any],
+    ) -> CreatePrivateKeyOptions:
+        key_label = options[f"{self.options_prefix}key_label"]
+        if not key_label:
+            raise CommandError(
+                f"--{self.argparse_prefix}key-label is a required option for this key backend."
+            )
+
+        so_pin, user_pin = self._get_pins(options)
+
+        if key_type == "EC" and elliptic_curve is None:
+            # NOTE: Currently all curves supported by cryptography are also supported by this backend.
+            #       If this changes, a check should be added here (if the default is not supported by the
+            #       backend).
+            elliptic_curve = model_settings.CA_DEFAULT_ELLIPTIC_CURVE.name
+
+        return CreatePrivateKeyOptions(
+            key_label=key_label,
+            key_type=key_type,
+            key_size=key_size,
+            elliptic_curve=elliptic_curve,
+            so_pin=so_pin,
+            user_pin=user_pin,
+        )
+
+    def get_use_parent_private_key_options(
+        self, ca: "CertificateAuthority", options: dict[str, Any]
+    ) -> HSMBackendUsePrivateKeyOptions:
+        so_pin, user_pin = self._get_pins(options, "parent-")
+        return HSMBackendUsePrivateKeyOptions.model_validate(
+            {"so_pin": so_pin, "user_pin": user_pin}, context={"ca": ca, "backend": self}, strict=True
+        )
+
+    def get_use_private_key_options(
+        self, ca: "CertificateAuthority", options: dict[str, Any]
+    ) -> HSMBackendUsePrivateKeyOptions:
+        so_pin, user_pin = self._get_pins(options)
+        return HSMBackendUsePrivateKeyOptions.model_validate(
+            {"so_pin": so_pin, "user_pin": user_pin}, context={"ca": ca, "backend": self}, strict=True
+        )
+
+    def get_store_private_key_options(self, options: dict[str, Any]) -> HSMBackendStorePrivateKeyOptions:
+        key_label = options[f"{self.options_prefix}key_label"]
+        so_pin, user_pin = self._get_pins(options)
+        return HSMBackendStorePrivateKeyOptions.model_validate(
+            {"key_label": key_label, "so_pin": so_pin, "user_pin": user_pin},
+            context={"backend": self},
+            strict=True,
+        )
+
+    def is_usable(
+        self,
+        ca: "CertificateAuthority",
+        use_private_key_options: Optional[HSMBackendUsePrivateKeyOptions] = None,
+    ) -> bool:
+        if not ca.key_backend_options or not isinstance(ca.key_backend_options, dict):
+            return False
+        for option in self._required_key_backend_options:
+            if not ca.key_backend_options.get(option):
+                return False
+        if use_private_key_options is None:
+            return True
+
+        try:
+            with self.session(
+                so_pin=use_private_key_options.so_pin, user_pin=use_private_key_options.user_pin
+            ) as session:
+                self._get_private_key(ca, session)
+            return True
+        except Exception:  # pylint: disable=broad-exception-caught  # want to always return bool
+            return False
+
+    def check_usable(
+        self, ca: "CertificateAuthority", use_private_key_options: HSMBackendUsePrivateKeyOptions
+    ) -> None:
+        if not ca.key_backend_options or not isinstance(ca.key_backend_options, dict):
+            raise ValueError("key backend options are not defined.")
+        for option in self._required_key_backend_options:
+            if not ca.key_backend_options.get(option):
+                raise ValueError(f"{option}: Required key option is not defined.")
+
+        with self.session(
+            so_pin=use_private_key_options.so_pin, user_pin=use_private_key_options.user_pin
+        ) as session:
+            self._get_private_key(ca, session)
+
+    def create_private_key(
+        self,
+        ca: "CertificateAuthority",
+        key_type: SupportedKeyType,  # type: ignore[override]  # more specific here
+        options: CreatePrivateKeyOptions,
+    ) -> tuple[CertificateIssuerPublicKeyTypes, HSMBackendUsePrivateKeyOptions]:
+        key_id = int_to_hex(x509.random_serial_number())
+        key_label = options.key_label
+
+        # Test that no private key with the given label exists. Some libraries (e.g. SoftHSM) don't treat the
+        # label as unique and will silently create a second key with the same label.
+        # NOTE: Using a rw session here, even though we don't need it. pkcs11 fails (at least with softhsm2)
+        #   if an so_pin is used and a read-only session is requested. Also, we have to use rw when creating
+        #   the key anyway.
+        with self.session(so_pin=options.so_pin, user_pin=options.user_pin, rw=True) as session:
+            try:
+                session.get_key(object_class=ObjectClass.PUBLIC_KEY, label=key_label)
+            except pkcs11.NoSuchKey:
+                pass  # this is what we hope for
+            else:
+                raise ValueError(f"{key_label}: Private key with this label already exists.")
+
+            if key_type == "RSA":
+                pkcs11_public_key, pkcs11_private_key = session.generate_keypair(
+                    pkcs11.KeyType.RSA, options.key_size, id=key_id.encode(), label=key_label, store=True
+                )
+
+                private_key: PKCS11PrivateKeyTypes = PKCS11RSAPrivateKey(
+                    session=session,
+                    key_id=key_id,
+                    key_label=key_label,
+                    pkcs11_private_key=pkcs11_private_key,
+                    pkcs11_public_key=pkcs11_public_key,
+                )
+                public_key = private_key.public_key()
+
+            elif key_type in ("Ed25519", "Ed448"):
+                named_curve_parameters = encode_named_curve_parameters(
+                    SignedDigestAlgorithmId(key_type.lower()).dotted
+                )
+
+                parameters = session.create_domain_parameters(
+                    KeyType.EC_EDWARDS, {pkcs11.Attribute.EC_PARAMS: named_curve_parameters}, local=True
+                )
+
+                pkcs11_public_key, pkcs11_private_key = parameters.generate_keypair(
+                    mechanism=pkcs11.Mechanism.EC_EDWARDS_KEY_PAIR_GEN,
+                    store=True,
+                    id=key_id.encode(),
+                    label=key_label,
+                )
+
+                if key_type == "Ed25519":
+                    private_key = PKCS11Ed25519PrivateKey(
+                        session=session,
+                        key_id=key_id,
+                        key_label=key_label,
+                        pkcs11_private_key=pkcs11_private_key,
+                        pkcs11_public_key=pkcs11_public_key,
+                    )
+                else:
+                    private_key = PKCS11Ed448PrivateKey(
+                        session=session,
+                        key_id=key_id,
+                        key_label=key_label,
+                        pkcs11_private_key=pkcs11_private_key,
+                        pkcs11_public_key=pkcs11_public_key,
+                    )
+                public_key = private_key.public_key()
+
+            elif key_type == "EC":
+                # TYPEHINT NOTE: elliptic curve is always set if key_type is EC.
+                elliptic_curve_name = options.elliptic_curve.lower()  # type: ignore[union-attr]
+                parameters = session.create_domain_parameters(
+                    KeyType.EC,
+                    {pkcs11.Attribute.EC_PARAMS: encode_named_curve_parameters(elliptic_curve_name)},
+                    local=True,
+                )
+
+                pkcs11_public_key, pkcs11_private_key = parameters.generate_keypair(
+                    store=True, id=key_id.encode(), label=key_label
+                )
+
+                private_key = PKCS11EllipticCurvePrivateKey(
+                    session=session,
+                    key_id=key_id,
+                    key_label=key_label,
+                    pkcs11_private_key=pkcs11_private_key,
+                    pkcs11_public_key=pkcs11_public_key,
+                )
+                public_key = private_key.public_key()
+            else:
+                raise ValueError(f"{key_type}: unknown key type")
+
+        ca.key_backend_options = {"key_id": key_id, "key_label": key_label, "key_type": key_type}
+        use_private_key_options = HSMBackendUsePrivateKeyOptions.model_validate(
+            {"so_pin": options.so_pin, "user_pin": options.user_pin}, context={"ca": ca, "backend": self}
+        )
+
+        return public_key, use_private_key_options
+
+    def store_private_key(
+        self,
+        ca: "CertificateAuthority",
+        key: CertificateIssuerPrivateKeyTypes,
+        certificate: x509.Certificate,
+        options: HSMBackendStorePrivateKeyOptions,
+    ) -> None:
+        key_id = int_to_hex(x509.random_serial_number())
+        public_key = certificate.public_key()
+
+        if isinstance(key, rsa.RSAPrivateKey):
+            key_type: SupportedKeyType = "RSA"
+            key_der = key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+            key_attrs = decode_rsa_private_key(key_der)
+            pub_der = public_key.public_bytes(
+                serialization.Encoding.DER, format=serialization.PublicFormat.PKCS1
+            )
+            pub_attrs = decode_rsa_public_key(pub_der)
+        elif isinstance(key, ec.EllipticCurvePrivateKey):
+            key_type = "EC"
+            key_der = key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+            key_attrs = decode_ec_private_key(key_der)
+            pub_der = public_key.public_bytes(
+                serialization.Encoding.DER, format=serialization.PublicFormat.SubjectPublicKeyInfo
+            )
+            pub_attrs = decode_ec_public_key(pub_der)
+        elif isinstance(key, (ed448.Ed448PrivateKey, ed25519.Ed25519PrivateKey)):
+            raise ValueError("Import of Ed448/Ed25519 keys is not implemented.")
+        else:
+            raise ValueError(f"{key}: Importing a key of this type is not supported.")
+
+        shared_attrs = {
+            pkcs11.Attribute.TOKEN: True,
+            pkcs11.Attribute.PRIVATE: True,
+            pkcs11.Attribute.ID: key_id.encode(),
+            pkcs11.Attribute.LABEL: options.key_label,
+        }
+        key_attrs.update(shared_attrs)
+        pub_attrs.update(shared_attrs)
+
+        with self.session(so_pin=options.so_pin, user_pin=options.user_pin, rw=True) as session:
+            session.create_object(key_attrs)
+            session.create_object(pub_attrs)
+
+        ca.key_backend_options = {"key_id": key_id, "key_label": options.key_label, "key_type": key_type}
+
+    def sign_certificate(
+        self,
+        ca: "CertificateAuthority",
+        use_private_key_options: HSMBackendUsePrivateKeyOptions,
+        public_key: CertificateIssuerPublicKeyTypes,
+        serial: int,
+        algorithm: Optional[AllowedHashTypes],
+        issuer: x509.Name,
+        subject: x509.Name,
+        expires: datetime,
+        extensions: Sequence[CertificateExtension],
+    ) -> x509.Certificate:
+        builder = get_cert_builder(expires, serial=serial)
+        builder = builder.public_key(public_key)
+        builder = builder.issuer_name(issuer)
+        builder = builder.subject_name(subject)
+        for extension in extensions:
+            builder = builder.add_extension(extension.value, critical=extension.critical)
+
+        with self.session(
+            so_pin=use_private_key_options.so_pin, user_pin=use_private_key_options.user_pin
+        ) as session:
+            private_key = self._get_private_key(ca, session)
+            return builder.sign(private_key=private_key, algorithm=algorithm)
+
+    def sign_certificate_revocation_list(
+        self,
+        ca: "CertificateAuthority",
+        use_private_key_options: HSMBackendUsePrivateKeyOptions,
+        builder: x509.CertificateRevocationListBuilder,
+        algorithm: Optional[AllowedHashTypes],
+    ) -> x509.CertificateRevocationList:
+        with self.session(
+            so_pin=use_private_key_options.so_pin, user_pin=use_private_key_options.user_pin
+        ) as session:
+            private_key = self._get_private_key(ca, session)
+            return builder.sign(private_key=private_key, algorithm=algorithm)

--- a/ca/django_ca/key_backends/hsm/keys.py
+++ b/ca/django_ca/key_backends/hsm/keys.py
@@ -1,0 +1,243 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Private key implementations that use an HSM in the background."""
+
+import hashlib
+from typing import ClassVar, Generic, NoReturn, Optional, TypeVar, Union, cast
+
+import pkcs11
+from pkcs11 import Session
+from pkcs11.constants import Attribute
+from pkcs11.util.ec import encode_ec_public_key, encode_ecdsa_signature
+from pkcs11.util.rsa import encode_rsa_public_key
+
+from asn1crypto.core import OctetString
+from asn1crypto.keys import PublicKeyInfo
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa, utils as asym_utils
+from cryptography.hazmat.primitives.asymmetric.padding import PSS, AsymmetricPadding, PKCS1v15
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.hazmat.primitives.serialization import load_der_public_key
+
+EdwardsPublicKeyTypeVar = TypeVar("EdwardsPublicKeyTypeVar", ed448.Ed448PublicKey, ed25519.Ed25519PublicKey)
+
+
+class PKCS11PrivateKeyMixin:
+    """Mixin providing common functionality to PKCS11 key implementations."""
+
+    # pylint: disable=missing-function-docstring  # implements standard functions of the base class.
+
+    key_type: pkcs11.KeyType
+
+    def __init__(
+        self,
+        session: Session,
+        key_id: str,
+        key_label: str,
+        pkcs11_private_key: Optional[pkcs11.PrivateKey] = None,
+        pkcs11_public_key: Optional[pkcs11.PublicKey] = None,
+    ) -> None:
+        self._session = session
+        self._key_id = key_id.encode()
+        self._key_label = key_label
+        self._pkcs11_private_key = pkcs11_private_key
+        self._pkcs11_public_key = pkcs11_public_key
+
+        super().__init__()
+
+    def decrypt(self, ciphertext: bytes, padding: AsymmetricPadding) -> bytes:
+        raise NotImplementedError(
+            "Decryption is not implemented for keys stored in a hardware security module (HSM)."
+        )
+
+    def private_bytes(
+        self,
+        encoding: serialization.Encoding,
+        format: serialization.PrivateFormat,  # pylint: disable=redefined-builtin  # given by cryptography
+        encryption_algorithm: serialization.KeySerializationEncryption,
+    ) -> bytes:
+        raise NotImplementedError(
+            "Private bytes cannot be retrieved for keys stored in a hardware security module (HSM)."
+        )
+
+    def private_numbers(self) -> NoReturn:
+        raise NotImplementedError(
+            "Private numbers cannot be retrieved for keys stored in a hardware security module (HSM)."
+        )
+
+    @property
+    def pkcs11_private_key(self) -> pkcs11.PrivateKey:
+        if self._pkcs11_private_key is None:
+            self._pkcs11_private_key = self._session.get_key(
+                key_type=self.key_type,
+                object_class=pkcs11.ObjectClass.PRIVATE_KEY,
+                id=self._key_id,
+                label=self._key_label,
+            )
+        return self._pkcs11_private_key
+
+    @property
+    def pkcs11_public_key(self) -> pkcs11.PublicKey:
+        if self._pkcs11_public_key is None:
+            self._pkcs11_public_key = self._session.get_key(
+                key_type=self.key_type,
+                object_class=pkcs11.ObjectClass.PUBLIC_KEY,
+                id=self._key_id,
+                label=self._key_label,
+            )
+        return self._pkcs11_public_key
+
+
+class PKCS11EdwardsPrivateKeyMixin(PKCS11PrivateKeyMixin, Generic[EdwardsPublicKeyTypeVar]):
+    """Specialized mixin for Ed448 and Ed5519 keys (which handle identical)."""
+
+    # pylint: disable=missing-function-docstring  # implements standard functions of the base class.
+
+    public_key_algorithm: ClassVar[str]
+    key_type = pkcs11.KeyType.EC_EDWARDS
+    cryptograph_key_type: EdwardsPublicKeyTypeVar
+
+    def private_bytes_raw(self) -> bytes:
+        raise NotImplementedError(
+            "Private bytes cannot be retrieved for keys stored in a hardware security module (HSM)."
+        )
+
+    def public_key(self) -> EdwardsPublicKeyTypeVar:
+        ec_point = bytes(OctetString.load(self.pkcs11_public_key[Attribute.EC_POINT]))
+        value = {"algorithm": {"algorithm": self.public_key_algorithm}, "public_key": ec_point}
+        public_key: bytes = PublicKeyInfo(value).dump()
+
+        return cast(EdwardsPublicKeyTypeVar, load_der_public_key(public_key))
+
+    def sign(self, data: bytes) -> bytes:
+        return self.pkcs11_private_key.sign(data, mechanism=pkcs11.Mechanism.EDDSA)  # type: ignore[no-any-return]
+
+
+# pylint: disable-next=abstract-method  # private key functions are deliberately not implemented in base.
+class PKCS11RSAPrivateKey(PKCS11PrivateKeyMixin, rsa.RSAPrivateKey):
+    """Private key implementation for RSA keys stored in a HSM."""
+
+    key_type = pkcs11.KeyType.RSA
+
+    def public_key(self) -> RSAPublicKey:
+        der_public_key = encode_rsa_public_key(self.pkcs11_public_key)
+        return cast(RSAPublicKey, load_der_public_key(der_public_key))
+
+    @property
+    def key_size(self) -> int:
+        return self.public_key().key_size
+
+    def sign(
+        self,
+        data: bytes,
+        padding: AsymmetricPadding,
+        algorithm: Union[asym_utils.Prehashed, hashes.HashAlgorithm],
+    ) -> bytes:
+        if isinstance(algorithm, asym_utils.Prehashed):
+            raise ValueError("Signing of prehashed data is not supported.")
+
+        if isinstance(algorithm, hashes.SHA224) and isinstance(padding, PSS):  # pragma: no cover
+            mechanism: hashes.HashAlgorithm = pkcs11.Mechanism.SHA224_RSA_PKCS_PSS
+        elif isinstance(algorithm, hashes.SHA224) and isinstance(padding, PKCS1v15):
+            mechanism = pkcs11.Mechanism.SHA224_RSA_PKCS
+        elif isinstance(algorithm, hashes.SHA256) and isinstance(padding, PSS):  # pragma: no cover
+            mechanism = pkcs11.Mechanism.SHA256_RSA_PKCS_PSS
+        elif isinstance(algorithm, hashes.SHA256) and isinstance(padding, PKCS1v15):
+            mechanism = pkcs11.Mechanism.SHA256_RSA_PKCS
+        elif isinstance(algorithm, hashes.SHA384) and isinstance(padding, PSS):  # pragma: no cover
+            mechanism = pkcs11.Mechanism.SHA384_RSA_PKCS_PSS
+        elif isinstance(algorithm, hashes.SHA384) and isinstance(padding, PKCS1v15):
+            mechanism = pkcs11.Mechanism.SHA384_RSA_PKCS
+        elif isinstance(algorithm, hashes.SHA512) and isinstance(padding, PSS):  # pragma: no cover
+            mechanism = pkcs11.Mechanism.SHA512_RSA_PKCS_PSS
+        elif isinstance(algorithm, hashes.SHA512) and isinstance(padding, PKCS1v15):
+            mechanism = pkcs11.Mechanism.SHA512_RSA_PKCS
+        elif isinstance(algorithm, (hashes.SHA3_224, hashes.SHA3_384, hashes.SHA3_256, hashes.SHA3_512)):
+            raise ValueError("SHA3 is not support by the HSM backend.")
+        else:
+            raise ValueError(
+                f"{algorithm.name} with {padding.name} padding: Unknown signing algorithm and/or padding."
+            )
+
+        # TYPEHINT NOTE: library is not type-hinted.
+        return self.pkcs11_private_key.sign(data, mechanism=mechanism)  # type: ignore[no-any-return]
+
+
+class PKCS11EllipticCurvePrivateKey(PKCS11PrivateKeyMixin, ec.EllipticCurvePrivateKey):
+    """Private key implementation for EC keys stored in a HSM."""
+
+    key_type = pkcs11.KeyType.EC
+
+    @property
+    def curve(self) -> ec.EllipticCurve:
+        return self.public_key().curve
+
+    def exchange(self, algorithm: ec.ECDH, peer_public_key: ec.EllipticCurvePublicKey) -> bytes:
+        raise NotImplementedError(
+            "exchange is not implemented for keys stored in a hardware security module (HSM)."
+        )
+
+    @property
+    def key_size(self) -> int:
+        return self.public_key().key_size
+
+    def public_key(self) -> ec.EllipticCurvePublicKey:
+        public_key = encode_ec_public_key(self.pkcs11_public_key)
+        return cast(ec.EllipticCurvePublicKey, load_der_public_key(public_key))
+
+    def sign(self, data: bytes, signature_algorithm: ec.EllipticCurveSignatureAlgorithm) -> bytes:
+        if isinstance(signature_algorithm.algorithm, hashes.SHA224):
+            hasher = hashlib.sha224()
+        elif isinstance(signature_algorithm.algorithm, hashes.SHA256):
+            hasher = hashlib.sha256()
+        elif isinstance(signature_algorithm.algorithm, hashes.SHA384):
+            hasher = hashlib.sha384()
+        elif isinstance(signature_algorithm.algorithm, hashes.SHA512):
+            hasher = hashlib.sha512()
+        elif isinstance(
+            signature_algorithm.algorithm,
+            (hashes.SHA3_224, hashes.SHA3_384, hashes.SHA3_256, hashes.SHA3_512),
+        ):
+            raise ValueError("SHA3 is not support by the HSM backend.")
+        elif isinstance(signature_algorithm.algorithm, asym_utils.Prehashed):
+            raise ValueError("Signing of prehashed data is not supported.")
+        else:
+            raise ValueError(f"{signature_algorithm.algorithm.name}: Signature algorithm is not supported.")
+
+        hasher.update(data)
+        data = hasher.digest()
+
+        signature = self.pkcs11_private_key.sign(data, mechanism=pkcs11.Mechanism.ECDSA)
+        return encode_ecdsa_signature(signature)  # type: ignore[no-any-return]
+
+
+# pylint: disable-next=abstract-method  # private key functions are deliberately not implemented in base.
+class PKCS11Ed25519PrivateKey(
+    PKCS11EdwardsPrivateKeyMixin[ed25519.Ed25519PublicKey], ed25519.Ed25519PrivateKey
+):
+    """Private key implementation for Ed25519 keys stored in a HSM."""
+
+    public_key_algorithm = "ed25519"
+
+
+# pylint: disable-next=abstract-method  # private key functions are deliberately not implemented in base.
+class PKCS11Ed448PrivateKey(PKCS11EdwardsPrivateKeyMixin[ed448.Ed448PublicKey], ed448.Ed448PrivateKey):
+    """Private key implementation for Ed448 keys stored in a HSM."""
+
+    public_key_algorithm = "ed448"
+
+
+PKCS11PrivateKeyTypes = Union[
+    PKCS11RSAPrivateKey, PKCS11Ed25519PrivateKey, PKCS11Ed448PrivateKey, PKCS11EllipticCurvePrivateKey
+]

--- a/ca/django_ca/key_backends/hsm/models.py
+++ b/ca/django_ca/key_backends/hsm/models.py
@@ -1,0 +1,92 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Models used by the HSM backend."""
+
+import typing
+from typing import TYPE_CHECKING, Optional, cast
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic_core.core_schema import ValidationInfo
+
+from django_ca import constants
+from django_ca.conf import model_settings
+from django_ca.key_backends.base import CreatePrivateKeyOptionsBaseModel
+from django_ca.key_backends.hsm.typehints import SupportedKeyType
+from django_ca.typehints import EllipticCurves
+
+if TYPE_CHECKING:
+    from django_ca.key_backends.hsm import HSMBackend
+
+
+class PinModelMixin:
+    """Mixin providing so/user pin and validation."""
+
+    so_pin: Optional[str] = None
+    user_pin: Optional[str] = None
+
+    @field_validator("so_pin", "user_pin", mode="after")
+    @classmethod
+    def load_pins_from_backend(cls, value: Optional[str], info: ValidationInfo) -> Optional[str]:
+        """Load pins from backend if configured."""
+        if info.context and value is None:
+            backend: HSMBackend = info.context.get("backend")
+            if backend is not None:  # pragma: no branch  # backend is always set
+                # TYPEHINT NOTE: field_name is always set in field validators for multiple fields.
+                return cast(Optional[str], getattr(backend, info.field_name))  # type: ignore[arg-type]
+        return value
+
+    @model_validator(mode="after")
+    def validate_pins(self) -> "typing.Self":
+        """Validate that exactly one of `so_pin` and `user_pin` is set."""
+        if self.so_pin is None and self.user_pin is None:
+            raise ValueError("Provide one of so_pin or user_pin.")
+        if self.so_pin is not None and self.user_pin is not None:
+            raise ValueError("Provide either so_pin or user_pin.")
+        return self
+
+
+class CreatePrivateKeyOptions(PinModelMixin, CreatePrivateKeyOptionsBaseModel):
+    """Options for initializing private keys."""
+
+    # NOTE: we set frozen here to prevent accidental coding mistakes. Models should be immutable.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    key_label: str
+    key_type: SupportedKeyType  # overwrites field from the base model
+    elliptic_curve: Optional[EllipticCurves]
+
+    @model_validator(mode="after")
+    def validate_elliptic_curve(self) -> "CreatePrivateKeyOptions":
+        """Validate that the elliptic curve is not set for invalid key types."""
+        if self.key_type == "EC" and self.elliptic_curve is None:
+            default_elliptic_curve_type = type(model_settings.CA_DEFAULT_ELLIPTIC_CURVE)
+            self.elliptic_curve = constants.ELLIPTIC_CURVE_NAMES[default_elliptic_curve_type]
+        elif self.key_type != "EC" and self.elliptic_curve is not None:
+            raise ValueError(f"Elliptic curves are not supported for {self.key_type} keys.")
+        return self
+
+
+class HSMBackendStorePrivateKeyOptions(PinModelMixin, BaseModel):
+    """Options for storing a private key."""
+
+    # NOTE: we set frozen here to prevent accidental coding mistakes. Models should be immutable.
+    model_config = ConfigDict(frozen=True)
+
+    key_label: str
+
+
+class HSMBackendUsePrivateKeyOptions(PinModelMixin, BaseModel):
+    """Options for using the private key."""
+
+    model_config = ConfigDict(frozen=True)

--- a/ca/django_ca/key_backends/hsm/session.py
+++ b/ca/django_ca/key_backends/hsm/session.py
@@ -1,0 +1,121 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Code for handling sessions for hardware security modules."""
+
+import threading
+from types import TracebackType
+from typing import Final, Optional
+
+import pkcs11
+from pkcs11 import Session
+from pkcs11._pkcs11 import lib as pkcs11_lib
+
+PoolKeyType = tuple[str, str, Optional[str], Optional[str]]
+
+
+class SessionPool:
+    """Thread-safe session pool for PKCS11 sessions."""
+
+    _lib_lock: Final[threading.Lock] = threading.Lock()
+    _lib_pool: Final[dict[str, pkcs11_lib]] = {}
+
+    _session_lock: Final[threading.Lock] = threading.Lock()
+    _session_pool: Final[dict[PoolKeyType, Session]] = {}
+    _session_refcount: Final[dict[PoolKeyType, int]] = {}
+
+    path: Final[str]
+    token_label: Final[str]
+    so_pin: Final[Optional[str]]
+    user_pin: Final[Optional[str]]
+    rw: Final[bool]
+
+    def __init__(
+        self, path: str, token_label: str, so_pin: Optional[str], user_pin: Optional[str], rw: bool = False
+    ) -> None:
+        if so_pin is None and user_pin is None:
+            raise ValueError("so_pin and user_pin cannot both be None.")
+        if so_pin is not None and user_pin is not None:
+            raise ValueError("Either so_pin and user_pin must be set.")
+
+        self.path = path
+        self.token_label = token_label
+        self.so_pin = so_pin
+        self.user_pin = user_pin
+        self.rw = rw
+
+    @classmethod
+    def acquire(
+        cls,
+        path: str,
+        token_label: str,
+        so_pin: Optional[str] = None,
+        user_pin: Optional[str] = None,
+        rw: bool = False,
+    ) -> Session:
+        """Open a new session with the given parameters."""
+        with cls._lib_lock:
+            if path not in cls._lib_pool:
+                cls._lib_pool[path] = pkcs11.lib(path)
+
+        with cls._session_lock:
+            pool_key = (path, token_label, so_pin, user_pin)
+            if pool_key not in cls._session_pool:
+                token = cls._lib_pool[path].get_token(token_label=token_label)
+                cls._session_pool[pool_key] = token.open(rw=rw, so_pin=so_pin, user_pin=user_pin)
+                cls._session_refcount[pool_key] = 1
+            else:
+                # Request a read/write session, but a read-only session is already present. According to the
+                # PKCS11 documentation, some libraries don't allow multiple sessions for the same token per
+                # process:
+                #
+                #   https://python-pkcs11.readthedocs.io/en/latest/concurrency.html
+                #
+                # Note that this does not happen in practice. A read/write session is only requested when
+                # generating or importing keys, and this always runs on the command-line, where no other
+                # session is ever present.
+                if rw is True and cls._session_pool[pool_key].rw is False:
+                    raise ValueError("Requested R/W session, but R/O session is already initialized.")
+
+                cls._session_refcount[pool_key] += 1
+
+            return cls._session_pool[pool_key]
+
+    @classmethod
+    def release(cls, path: str, token_label: str, so_pin: Optional[str], user_pin: Optional[str]) -> None:
+        """Close session if no reference is known."""
+        with cls._session_lock:
+            pool_key = (path, token_label, so_pin, user_pin)
+            cls._session_refcount[pool_key] -= 1
+
+            if cls._session_refcount[pool_key] == 0:
+                cls._session_pool[pool_key].close()
+                del cls._session_pool[pool_key]
+                del cls._session_refcount[pool_key]
+
+                # If no session for this library is left open, reinitialize it
+                if any(e for e in cls._session_pool if e[0] == path) is False:
+                    cls._lib_pool[path].reinitialize()
+
+    def __enter__(self) -> Session:
+        return self.acquire(
+            self.path, self.token_label, so_pin=self.so_pin, user_pin=self.user_pin, rw=self.rw
+        )
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.release(self.path, self.token_label, so_pin=self.so_pin, user_pin=self.user_pin)

--- a/ca/django_ca/key_backends/hsm/typehints.py
+++ b/ca/django_ca/key_backends/hsm/typehints.py
@@ -1,0 +1,18 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Type aliases used in HSM code."""
+
+from typing import Literal
+
+SupportedKeyType = Literal["RSA", "EC", "Ed25519", "Ed448"]

--- a/ca/django_ca/management/base.py
+++ b/ca/django_ca/management/base.py
@@ -429,7 +429,7 @@ class BaseSignCommand(BaseCommand, metaclass=abc.ABCMeta):
             try:
                 return parse_name_rfc4514(value)
             except ValueError as ex:  # pragma: only cryptography>=43.0
-                raise CommandError(str(ex)) from ex
+                raise CommandError(ex) from ex
         # COVERAGE NOTE: Already covered by argparse
         raise ValueError(f"{name_format}: Unknown subject format.")  # pragma: no cover
 

--- a/ca/django_ca/tasks.py
+++ b/ca/django_ca/tasks.py
@@ -92,7 +92,7 @@ def cache_crl(serial: str, key_backend_options: Optional[dict[str, JSON]] = None
 
     ca = CertificateAuthority.objects.get(serial=serial)
     key_backend_options_model = ca.key_backend.use_model.model_validate(
-        key_backend_options, context={"ca": ca}, strict=True
+        key_backend_options, context={"ca": ca, "backend": ca.key_backend}, strict=True
     )
     ca.cache_crls(key_backend_options_model)
 
@@ -160,7 +160,7 @@ def generate_ocsp_key(
 
     ca: CertificateAuthority = CertificateAuthority.objects.get(serial=parameters.serial)
     key_backend_options_model = ca.key_backend.use_model.model_validate(
-        key_backend_options, context={"ca": ca}, strict=True
+        key_backend_options, context={"ca": ca, "backend": ca.key_backend}, strict=True
     )
 
     value = ca.generate_ocsp_key(

--- a/ca/django_ca/tests/base/conftest_helpers.py
+++ b/ca/django_ca/tests/base/conftest_helpers.py
@@ -218,7 +218,10 @@ def generate_cert_fixture(name: str) -> typing.Callable[["SubRequest"], Iterator
         if data["cat"] in ("contrib", "sphinx-contrib"):
             pub_fixture_name = f"contrib_{pub_fixture_name}"
         pub = request.getfixturevalue(pub_fixture_name)
-        cert = load_cert(ca, None, pub, data.get("profile", ""))
+        csr = None
+        if "csr" in data:
+            csr = data["csr"]["parsed"]
+        cert = load_cert(ca, csr, pub, data.get("profile", ""))
 
         yield cert  # NOTE: Yield must be outside the freeze-time block, or durations are wrong
 

--- a/ca/django_ca/tests/base/utils.py
+++ b/ca/django_ca/tests/base/utils.py
@@ -99,9 +99,7 @@ class DummyBackend(KeyBackend[DummyModel, DummyModel, DummyModel]):  # pragma: n
     ) -> tuple[CertificateIssuerPublicKeyTypes, DummyModel]:
         return None, DummyModel()  # type: ignore[return-value]
 
-    def get_use_private_key_options(
-        self, ca: Optional[CertificateAuthority], options: dict[str, Any]
-    ) -> DummyModel:
+    def get_use_private_key_options(self, ca: CertificateAuthority, options: dict[str, Any]) -> DummyModel:
         return DummyModel()
 
     def is_usable(
@@ -136,7 +134,11 @@ class DummyBackend(KeyBackend[DummyModel, DummyModel, DummyModel]):  # pragma: n
         return None  # type: ignore[return-value]
 
     def store_private_key(
-        self, ca: "CertificateAuthority", key: CertificateIssuerPrivateKeyTypes, options: DummyModel
+        self,
+        ca: "CertificateAuthority",
+        key: CertificateIssuerPrivateKeyTypes,
+        certificate: x509.Certificate,
+        options: DummyModel,
     ) -> None:
         return None
 

--- a/ca/django_ca/tests/commands/test_sign_cert.py
+++ b/ca/django_ca/tests/commands/test_sign_cert.py
@@ -566,6 +566,14 @@ def test_secondary_backend(pwd: CertificateAuthority, rfc4514_subject: str) -> N
     assert_signature([pwd], cert)
 
 
+def test_hsm_backend(usable_hsm_ca: CertificateAuthority, rfc4514_subject: str) -> None:
+    """Test signing a certificate with a CA that is in a HSM."""
+    with assert_create_cert_signals() as (pre, post):
+        sign_cert(usable_hsm_ca, rfc4514_subject, stdin=csr)
+    cert = Certificate.objects.get()
+    assert_signature([usable_hsm_ca], cert)
+
+
 def test_encrypted_ca_with_settings(
     usable_pwd: CertificateAuthority, rfc4514_subject: str, settings: SettingsWrapper
 ) -> None:

--- a/ca/django_ca/tests/key_backends/hsm/conftest.py
+++ b/ca/django_ca/tests/key_backends/hsm/conftest.py
@@ -1,0 +1,54 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Fixtures for HSM testing."""
+
+from collections.abc import Iterator
+
+from pkcs11._pkcs11 import Session
+
+from django.conf import settings
+
+import pytest
+
+from django_ca.key_backends.hsm.session import SessionPool
+
+# pylint: disable=redefined-outer-name  # usefixtures does not work on fixtures.
+
+
+@pytest.fixture
+def session_pool() -> Iterator[None]:
+    """Get a clean session pool."""
+    # Reinitialize the library, so that any token created before is also visible (SoftHSM only sees token
+    # present at initialization time).
+    # pylint: disable=use-implicit-booleaness-not-comparison
+    # pylint: disable=protected-access  # deliberate access in this entire function
+    for lib in SessionPool._lib_pool.values():
+        lib.reinitialize()
+
+    # Assert that the session pool *is* clean. Any test leaving sessions intact would show up here.
+    assert SessionPool._session_pool == {}
+    assert SessionPool._session_refcount == {}
+
+    yield
+
+    # Make sure that we leave no open sessions.
+    assert SessionPool._session_pool == {}
+    assert SessionPool._session_refcount == {}
+
+
+@pytest.fixture
+def session(softhsm_token: str, session_pool: None) -> Session:  # pylint: disable=unused-argument
+    """Fixture providing a fresh (read-only) session."""
+    with SessionPool(settings.PKCS11_PATH, softhsm_token, None, settings.PKCS11_USER_PIN) as session:
+        yield session

--- a/ca/django_ca/tests/key_backends/hsm/test_backend.py
+++ b/ca/django_ca/tests/key_backends/hsm/test_backend.py
@@ -1,0 +1,184 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Main tests for the HSM backend."""
+
+from unittest.mock import patch
+
+import pkcs11
+
+from cryptography import x509
+
+from django.conf import settings
+
+import pytest
+
+from django_ca.key_backends import key_backends
+from django_ca.key_backends.hsm import HSMBackend
+from django_ca.key_backends.hsm.models import (
+    CreatePrivateKeyOptions,
+    HSMBackendStorePrivateKeyOptions,
+    HSMBackendUsePrivateKeyOptions,
+)
+from django_ca.models import CertificateAuthority
+
+
+def test_session_with_session_read_only_exception(hsm_backend: HSMBackend) -> None:
+    """Test exception message when SessionReadOnly() is raised."""
+    with pytest.raises(pkcs11.PKCS11Error, match=r"^Attempting to write to a read-only session\.$"):
+        with hsm_backend.session(so_pin=None, user_pin=settings.PKCS11_USER_PIN) as session:
+            with patch.object(session, "get_key", side_effect=pkcs11.SessionReadOnly()):
+                session.get_key()
+
+
+def test_session_with_unknown_pkcs11_exception(hsm_backend: HSMBackend) -> None:
+    """Test exception message when a generic PKCS11 error is raised."""
+    with pytest.raises(pkcs11.PKCS11Error, match=r"^Unknown pkcs11 error \(SessionCount\)\.$"):
+        with hsm_backend.session(so_pin=None, user_pin=settings.PKCS11_USER_PIN) as session:
+            with patch.object(session, "get_key", side_effect=pkcs11.SessionCount()):
+                session.get_key()
+
+
+@pytest.mark.usefixtures("softhsm_token")
+def test_invalid_token_configuration() -> None:
+    """Test validation of so_pin/user_pin."""
+    backend = HSMBackend("test", settings.PKCS11_PATH, "my-token", user_pin=settings.PKCS11_USER_PIN)
+    with pytest.raises(pkcs11.NoSuchToken, match=r"^my-token: Token not found\.$"):
+        with backend.session(so_pin=None, user_pin=settings.PKCS11_USER_PIN):
+            pass
+
+
+def test_invalid_pin_configuration() -> None:
+    """Test validation of so_pin/user_pin."""
+    with pytest.raises(ValueError, match=r"^test: Set either so_pin or user_pin\.$"):
+        HSMBackend("test", "/path", "token", so_pin="so-pin", user_pin="user-pin")
+
+
+@pytest.mark.usefixtures("softhsm_token")
+def test_invalid_private_key_type(root: CertificateAuthority) -> None:
+    """Test an invalid private key."""
+    root.key_backend_alias = "hsm"
+    root.key_backend_options = {"key_id": "123", "key_label": "label", "key_type": "WRONG"}
+    root.save()
+    use_options = HSMBackendUsePrivateKeyOptions(user_pin=settings.PKCS11_USER_PIN)
+    with pytest.raises(ValueError, match=r"^WRONG: Unsupported key type\.$"):
+        root.check_usable(use_options)
+
+
+def test_is_usable_with_no_options(root: CertificateAuthority) -> None:
+    """Test that is_usable() returns True if no options are passed."""
+    root.key_backend_alias = "hsm"
+    root.key_backend_options = {"key_id": "123", "key_label": "label", "key_type": "RSA"}
+    root.save()
+    assert root.is_usable() is True
+    assert root.is_usable(None) is True
+
+
+@pytest.mark.usefixtures("softhsm_token")
+def test_is_usable_with_wrong_user_pin(root: CertificateAuthority) -> None:
+    """Test that is_usable() returns False if the wrong pin is passed."""
+    root.key_backend_alias = "hsm"
+    root.key_backend_options = {"key_id": "123", "key_label": "label", "key_type": "RSA"}
+    root.save()
+    assert root.is_usable(HSMBackendUsePrivateKeyOptions(user_pin="wrong")) is False
+
+
+def test_no_private_key_options(root: CertificateAuthority) -> None:
+    """Test ...usable() with empty private key options."""
+    root.key_backend_alias = "hsm"
+    root.key_backend_options = {}
+    root.save()
+    use_options = HSMBackendUsePrivateKeyOptions(user_pin=settings.PKCS11_USER_PIN)
+    assert root.is_usable(use_options) is False
+    with pytest.raises(ValueError, match=r"^key backend options are not defined\.$"):
+        root.check_usable(use_options)
+
+
+def test_private_key_options_not_a_dict(root: CertificateAuthority) -> None:
+    """Test ...usable() with private key options that are not a dict."""
+    root.key_backend_alias = "hsm"
+    root.key_backend_options = []
+    root.save()
+    use_options = HSMBackendUsePrivateKeyOptions(user_pin=settings.PKCS11_USER_PIN)
+    assert root.is_usable(use_options) is False
+    with pytest.raises(ValueError, match=r"^key backend options are not defined\.$"):
+        root.check_usable(use_options)
+
+
+# pylint: disable-next=protected-access  # okay in test cases
+@pytest.mark.parametrize("parameter", HSMBackend._required_key_backend_options)
+def test_private_key_options_missing_parameter(root: CertificateAuthority, parameter: str) -> None:
+    """Test ...usable() with private key options that are missing a value."""
+    root.key_backend_alias = "hsm"
+    root.key_backend_options = {"key_id": "123", "key_label": "label", "key_type": "RSA"}
+    del root.key_backend_options[parameter]
+    root.save()
+
+    use_options = HSMBackendUsePrivateKeyOptions(user_pin=settings.PKCS11_USER_PIN)
+    assert root.is_usable(use_options) is False
+
+    with pytest.raises(ValueError, match=rf"^{parameter}: Required key option is not defined\.$"):
+        root.check_usable(use_options)
+
+
+@pytest.mark.usefixtures("softhsm_token")
+@pytest.mark.parametrize("key_type", HSMBackend.supported_key_types)
+def test_create_private_key_with_read_only_session(
+    root: CertificateAuthority, ca_name: str, key_type: str
+) -> None:
+    """Test creating a private key if a read-only session is already open."""
+    root.key_backend_alias = "hsm"
+    root.key_backend_options = {"key_id": "123", "key_label": "label", "key_type": "RSA"}
+    root.save()
+
+    options = CreatePrivateKeyOptions(
+        key_type=key_type, key_label=ca_name, elliptic_curve=None, user_pin=settings.PKCS11_USER_PIN
+    )
+
+    backend: HSMBackend = key_backends["hsm"]  # type: ignore[assignment]
+    with pytest.raises(
+        ValueError, match=r"^Requested R/W session, but R/O session is already initialized\.$"
+    ):
+        with backend.session(so_pin=None, user_pin=settings.PKCS11_USER_PIN):
+            backend.create_private_key(root, options.key_type, options)
+
+
+@pytest.mark.usefixtures("softhsm_token")
+def test_create_private_key_with_unknown_key_type(root: CertificateAuthority, ca_name: str) -> None:
+    """Test creating a private key if a read-only session is already open."""
+    root.key_backend_alias = "hsm"
+    root.key_backend_options = {"key_id": "123", "key_label": "label", "key_type": "WRONG"}
+    root.save()
+
+    options = CreatePrivateKeyOptions(
+        key_type="RSA", key_label=ca_name, elliptic_curve=None, user_pin=settings.PKCS11_USER_PIN
+    )
+
+    backend: HSMBackend = key_backends["hsm"]  # type: ignore[assignment]
+    with pytest.raises(ValueError, match=r"^WRONG: unknown key type$"):
+        backend.create_private_key(root, "WRONG", options)  # type: ignore[arg-type]  # what we test
+
+
+def test_store_private_key_with_unknown_type(
+    root: CertificateAuthority, root_cert_pub: x509.Certificate
+) -> None:
+    """Test storing a private key with an unknown type."""
+    options = HSMBackendStorePrivateKeyOptions(user_pin="abc", key_label="def")
+    backend: HSMBackend = key_backends["hsm"]  # type: ignore[assignment]
+    with pytest.raises(ValueError, match=r"^True: Importing a key of this type is not supported\.$"):
+        backend.store_private_key(
+            root,
+            True,  # type: ignore[arg-type]  # what we test
+            root_cert_pub,
+            options,
+        )

--- a/ca/django_ca/tests/key_backends/hsm/test_keys.py
+++ b/ca/django_ca/tests/key_backends/hsm/test_keys.py
@@ -1,0 +1,171 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Tests for models used in the HSM key backend."""
+
+from typing import Union, cast
+from unittest.mock import patch
+
+import pkcs11
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
+
+from django.conf import settings
+
+import pytest
+
+from django_ca.key_backends import key_backends
+from django_ca.key_backends.hsm import HSMBackend
+from django_ca.key_backends.hsm.keys import (
+    PKCS11Ed448PrivateKey,
+    PKCS11Ed25519PrivateKey,
+    PKCS11EllipticCurvePrivateKey,
+    PKCS11PrivateKeyTypes,
+    PKCS11RSAPrivateKey,
+)
+
+
+@pytest.mark.usefixtures("softhsm_token")
+def test_private_key_caching() -> None:
+    """Test caching of private keys."""
+    obj = object()
+    key_backend = cast(HSMBackend, key_backends["hsm"])
+    with key_backend.session(so_pin=None, user_pin=settings.PKCS11_USER_PIN) as session:
+        cert = PKCS11RSAPrivateKey(session, "foo", "bar")
+        with patch.object(session, "get_key", autospec=True, return_value=obj) as mock:
+            assert cert.pkcs11_private_key is obj
+            assert cert.pkcs11_private_key is obj
+
+        # Check that the mock was called only once
+        mock.assert_called_once_with(
+            key_type=pkcs11.KeyType.RSA, object_class=pkcs11.ObjectClass.PRIVATE_KEY, id=b"foo", label="bar"
+        )
+
+
+@pytest.mark.usefixtures("softhsm_token")
+def test_public_key_caching() -> None:
+    """Test caching of public keys."""
+    obj = object()
+    key_backend = cast(HSMBackend, key_backends["hsm"])
+    with key_backend.session(so_pin=None, user_pin=settings.PKCS11_USER_PIN) as session:
+        cert = PKCS11RSAPrivateKey(session, "foo", "bar")
+        with patch.object(session, "get_key", autospec=True, return_value=obj) as mock:
+            assert cert.pkcs11_public_key is obj
+            assert cert.pkcs11_public_key is obj
+
+        # Check that the mock was called only once
+        mock.assert_called_once_with(
+            key_type=pkcs11.KeyType.RSA, object_class=pkcs11.ObjectClass.PUBLIC_KEY, id=b"foo", label="bar"
+        )
+
+
+@pytest.mark.parametrize(
+    "key_class",
+    (PKCS11RSAPrivateKey, PKCS11EllipticCurvePrivateKey, PKCS11Ed25519PrivateKey, PKCS11Ed448PrivateKey),
+)
+def test_not_implemented_error(key_class: type[PKCS11PrivateKeyTypes]) -> None:
+    """Test methods that are not implemented."""
+    key: PKCS11PrivateKeyTypes = key_class(None, "key_id", "key_label")
+
+    error = r"^Private numbers cannot be retrieved for keys stored in a hardware security module \(HSM\)\.$"
+    with pytest.raises(NotImplementedError, match=error):
+        key.private_numbers()
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"^Private bytes cannot be retrieved for keys stored in a hardware security module \(HSM\)\.$",
+    ):
+        key.private_bytes(Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption())
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"^Decryption is not implemented for keys stored in a hardware security module \(HSM\)\.$",
+    ):
+        key.decrypt(b"foo", PKCS1v15())
+
+
+def test_rsa_with_prehashed() -> None:
+    """Test signing data with prehashed data, which we do not support."""
+    key = PKCS11RSAPrivateKey(None, "key_id", "key_label")
+    with pytest.raises(ValueError, match=r"^Signing of prehashed data is not supported\.$"):
+        key.sign(b"", PKCS1v15(), Prehashed(hashes.SHA512()))
+
+
+def test_rsa_with_sha3_error() -> None:
+    """Test signing data with SHA3, which is unsupported (by the underlying library)."""
+    key = PKCS11RSAPrivateKey(None, "key_id", "key_label")
+    with pytest.raises(ValueError, match=r"^SHA3 is not support by the HSM backend\.$"):
+        key.sign(b"", PKCS1v15(), hashes.SHA3_256())
+
+
+def test_rsa_with_unsupported_algorithm() -> None:
+    """Test signing data with an unsupported algorithms."""
+    key = PKCS11RSAPrivateKey(None, "key_id", "key_label")
+    with pytest.raises(
+        ValueError,
+        match=r"^blake2s with EMSA-PKCS1-v1_5 padding: Unknown signing algorithm and/or padding\.$",
+    ):
+        key.sign(b"", PKCS1v15(), hashes.BLAKE2s(32))
+
+
+def test_elliptic_curve_key_not_implemented_error() -> None:
+    """Test methods that are not implemented for elliptic curve keys."""
+    key = PKCS11EllipticCurvePrivateKey(None, "key_id", "key_label")
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"^exchange is not implemented for keys stored in a hardware security module \(HSM\)\.$",
+    ):
+        key.exchange(None, None)  # type: ignore[arg-type]  # don't care here
+
+
+def test_elliptic_curve_with_sha3_error() -> None:
+    """Test signing data with SHA3, which is unsupported (by the underlying library)."""
+    key = PKCS11EllipticCurvePrivateKey(None, "key_id", "key_label")
+    algo = ec.ECDSA(hashes.SHA3_256())
+    with pytest.raises(ValueError, match=r"^SHA3 is not support by the HSM backend\.$"):
+        key.sign(b"", algo)
+
+
+def test_elliptic_curve_with_unsupported_algorithm() -> None:
+    """Test signing data with an unsupported algorithm."""
+    key = PKCS11EllipticCurvePrivateKey(None, "key_id", "key_label")
+    algo = ec.ECDSA(hashes.BLAKE2s(32))
+    with pytest.raises(ValueError, match=r"^blake2s: Signature algorithm is not supported\.$"):
+        key.sign(b"", algo)
+
+
+def test_elliptic_curve_with_prehashed_data() -> None:
+    """Test signing data with prehashed data."""
+    key = PKCS11EllipticCurvePrivateKey(None, "key_id", "key_label")
+    algo = ec.ECDSA(Prehashed(hashes.BLAKE2s(32)))
+    with pytest.raises(ValueError, match=r"^Signing of prehashed data is not supported\.$"):
+        key.sign(b"", algo)
+
+
+@pytest.mark.parametrize("key_class", (PKCS11Ed25519PrivateKey, PKCS11Ed448PrivateKey))
+def test_ed_key_not_implemented_error(
+    key_class: type[Union[PKCS11Ed25519PrivateKey, PKCS11Ed448PrivateKey]],
+) -> None:
+    """Test methods that are not implemented for Ed448/Ed25519 keys."""
+    key: Union[PKCS11Ed25519PrivateKey, PKCS11Ed448PrivateKey] = key_class(None, "key_id", "key_label")
+
+    with pytest.raises(
+        NotImplementedError,
+        match=r"^Private bytes cannot be retrieved for keys stored in a hardware security module \(HSM\)\.$",
+    ):
+        key.private_bytes_raw()

--- a/ca/django_ca/tests/key_backends/hsm/test_models.py
+++ b/ca/django_ca/tests/key_backends/hsm/test_models.py
@@ -1,0 +1,47 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Tests for models used in the HSM key backend."""
+
+from typing import Optional
+
+import pytest
+
+from django_ca.key_backends.hsm.models import CreatePrivateKeyOptions, HSMBackendUsePrivateKeyOptions
+
+
+@pytest.mark.parametrize("so_pin,user_pin", (("so-pin-value", None), (None, "user-pin-value")))
+def test_pins(so_pin: Optional[str], user_pin: Optional[str]) -> None:
+    """Test valid pin configurations."""
+    model = HSMBackendUsePrivateKeyOptions(so_pin=so_pin, user_pin=user_pin)
+    assert model.so_pin == so_pin
+    assert model.user_pin == user_pin
+
+
+@pytest.mark.parametrize(
+    "so_pin,user_pin,error",
+    (
+        (None, None, r"Provide one of so_pin or user_pin\."),
+        ("so-pin-value", "user-pin-value", r"Provide either so_pin or user_pin\."),
+    ),
+)
+def test_invalid_pins(so_pin: Optional[str], user_pin: Optional[str], error: str) -> None:
+    """Test invalid pin configurations."""
+    with pytest.raises(ValueError, match=error):
+        HSMBackendUsePrivateKeyOptions(so_pin=so_pin, user_pin=user_pin)
+
+
+def test_with_elliptic_curve_with_rsa_key() -> None:
+    """Test creating a model with an elliptic curve with a key type that doesn't support it."""
+    with pytest.raises(ValueError, match=r"Elliptic curves are not supported for RSA keys."):
+        CreatePrivateKeyOptions(key_label="foo", user_pin="123", key_type="RSA", elliptic_curve="sect571r1")

--- a/ca/django_ca/tests/key_backends/hsm/test_session.py
+++ b/ca/django_ca/tests/key_backends/hsm/test_session.py
@@ -1,0 +1,129 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+
+"""Test HSM related code."""
+
+import subprocess
+from collections.abc import Iterator
+from typing import Optional
+
+from pkcs11._pkcs11 import Session
+
+from django.conf import settings
+from django.utils.crypto import get_random_string
+
+import pytest
+
+from django_ca.key_backends.hsm.session import SessionPool
+
+PoolKeyType = tuple[str, str, Optional[str], Optional[str]]
+
+# pylint: disable=redefined-outer-name  # several fixtures are defined here
+# pylint: disable=protected-access  # we test class internals throughout this module
+
+
+@pytest.fixture
+def pool_key(softhsm_token: str) -> Iterator[PoolKeyType]:
+    """Minor fixture to return the pool key for the default settings."""
+    yield settings.PKCS11_PATH, softhsm_token, None, settings.PKCS11_USER_PIN
+
+
+@pytest.fixture
+def second_softhsm_token(softhsm_token: str) -> Iterator[str]:  # pylint: disable=unused-argument
+    """Fixture to create a second softhsm token."""
+    label = f"pytest.{get_random_string(8)}.dual"
+
+    so_pin = settings.PKCS11_SO_PIN
+    pin = settings.PKCS11_USER_PIN
+
+    subprocess.run(
+        ["softhsm2-util", "--init-token", "--free", "--label", label, "--so-pin", so_pin, "--pin", pin],
+        check=True,
+    )
+
+    yield label
+
+    subprocess.run(["softhsm2-util", "--delete-token", "--token", label], check=True)
+
+
+def test_duplicate_session(softhsm_token: str, session: Session, pool_key: PoolKeyType) -> None:
+    """Test that a second session request does not open a new session."""
+    assert isinstance(session, Session)
+    assert SessionPool._session_pool == {pool_key: session}
+    assert SessionPool._session_refcount == {pool_key: 1}
+
+    # Get another session, even though it's in the same thread, refcount still goes up
+    with SessionPool(settings.PKCS11_PATH, softhsm_token, None, settings.PKCS11_USER_PIN) as second_session:
+        assert session is second_session
+        assert isinstance(second_session, Session)
+        assert SessionPool._session_pool == {pool_key: session}
+        assert SessionPool._session_refcount == {pool_key: 2}
+
+    # Test that second session was cleaned up
+    assert SessionPool._session_pool == {pool_key: session}
+    assert SessionPool._session_refcount == {pool_key: 1}
+
+
+def test_duplicate_rw_session(softhsm_token: str, session: Session, pool_key: PoolKeyType) -> None:
+    """Test that requesting a read/write session when it is already open read-only is an error."""
+    assert SessionPool._session_pool == {pool_key: session}
+    assert SessionPool._session_refcount == {pool_key: 1}
+    with pytest.raises(
+        ValueError, match=r"^Requested R/W session, but R/O session is already initialized\.$"
+    ):
+        with SessionPool(settings.PKCS11_PATH, softhsm_token, None, settings.PKCS11_USER_PIN, rw=True):
+            pass
+
+    # Test that the ref count has not increased
+    assert SessionPool._session_pool == {pool_key: session}
+    assert SessionPool._session_refcount == {pool_key: 1}
+
+
+def test_two_sessions(second_softhsm_token: str, session: Session, pool_key: PoolKeyType) -> None:
+    """Test creating a second token with dual sessions."""
+    # assert that we have one session in the beginning
+    assert SessionPool._session_pool == {pool_key: session}
+    assert SessionPool._session_refcount == {pool_key: 1}
+
+    pin = settings.PKCS11_USER_PIN
+    second_pool_key = (settings.PKCS11_PATH, second_softhsm_token, None, pin)
+
+    # Create a second session and observe dual session pool
+    with SessionPool(settings.PKCS11_PATH, second_softhsm_token, None, pin) as second_session:
+        assert SessionPool._session_pool == {pool_key: session, second_pool_key: second_session}
+        assert SessionPool._session_refcount == {pool_key: 1, second_pool_key: 1}
+
+        # Try to get a nested session...
+        with SessionPool(settings.PKCS11_PATH, second_softhsm_token, None, pin) as third_session:
+            assert second_session is third_session
+            assert SessionPool._session_pool == {pool_key: session, second_pool_key: second_session}
+            assert SessionPool._session_refcount == {pool_key: 1, second_pool_key: 2}
+
+    # session was cleared from pool
+    assert SessionPool._session_pool == {pool_key: session}
+    assert SessionPool._session_refcount == {pool_key: 1}
+
+
+def test_both_pins_empty() -> None:
+    """Test error when both so_pin and user_pin are not set."""
+    with pytest.raises(ValueError, match=r"^so_pin and user_pin cannot both be None\.$"):
+        with SessionPool(settings.PKCS11_PATH, "any", None, None):
+            pass
+
+
+def test_both_pins_set() -> None:
+    """Test error when both so_pin and user_pin are not set."""
+    with pytest.raises(ValueError, match=r"^Either so_pin and user_pin must be set\.$"):
+        with SessionPool(settings.PKCS11_PATH, "any", "foo", "bar"):
+            pass

--- a/ca/django_ca/tests/key_backends/test_base.py
+++ b/ca/django_ca/tests/key_backends/test_base.py
@@ -56,6 +56,7 @@ def test_key_backends_iter(settings: SettingsWrapper) -> None:
     assert list(key_backends) == [
         key_backends[model_settings.CA_DEFAULT_KEY_BACKEND],
         key_backends["secondary"],
+        key_backends["hsm"],
     ]
 
     settings.CA_KEY_BACKENDS = {

--- a/ca/django_ca/tests/utils/test_get_private_key_type.py
+++ b/ca/django_ca/tests/utils/test_get_private_key_type.py
@@ -1,0 +1,37 @@
+# This file is part of django-ca (https://github.com/mathiasertl/django-ca).
+#
+# django-ca is free software: you can redistribute it and/or modify it under the terms of the GNU General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# django-ca is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License along with django-ca. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""Test get_private_key_type function."""
+
+import pytest
+
+from django_ca.key_backends.storages import StoragesBackend, UsePrivateKeyOptions
+from django_ca.models import CertificateAuthority
+from django_ca.utils import get_private_key_type
+
+
+def test_get_private_key_type(key_backend: StoragesBackend, usable_cas: list[CertificateAuthority]) -> None:
+    """Test the normal operation of this function."""
+    cas = {ca.name: ca for ca in usable_cas}
+
+    assert get_private_key_type(key_backend.get_key(cas["root"], UsePrivateKeyOptions())) == "RSA"
+    assert get_private_key_type(key_backend.get_key(cas["dsa"], UsePrivateKeyOptions())) == "DSA"
+    assert get_private_key_type(key_backend.get_key(cas["ec"], UsePrivateKeyOptions())) == "EC"
+    assert get_private_key_type(key_backend.get_key(cas["ed25519"], UsePrivateKeyOptions())) == "Ed25519"
+    assert get_private_key_type(key_backend.get_key(cas["ed448"], UsePrivateKeyOptions())) == "Ed448"
+
+
+def test_get_private_key_type_with_invalid_type() -> None:
+    """Test passing an invalid type."""
+    with pytest.raises(ValueError, match="^True: Unknown private key type.$"):
+        get_private_key_type(True)  # type: ignore[arg-type]  # what we test

--- a/ca/django_ca/utils.py
+++ b/ca/django_ca/utils.py
@@ -638,6 +638,21 @@ def generate_private_key(
     raise ValueError(f"{key_type}: Unknown key type.")
 
 
+def get_private_key_type(private_key: CertificateIssuerPrivateKeyTypes) -> ParsableKeyType:
+    """Get the private key type as string from a given private key."""
+    if isinstance(private_key, dsa.DSAPrivateKey):
+        return "DSA"
+    if isinstance(private_key, rsa.RSAPrivateKey):
+        return "RSA"
+    if isinstance(private_key, ec.EllipticCurvePrivateKey):
+        return "EC"
+    if isinstance(private_key, ed25519.Ed25519PrivateKey):
+        return "Ed25519"
+    if isinstance(private_key, ed448.Ed448PrivateKey):
+        return "Ed448"
+    raise ValueError(f"{private_key}: Unknown private key type.")
+
+
 def parse_other_name(name: str) -> x509.OtherName:
     """Parse a formatted :py:class:`~cg:cryptography.x509.OtherName` instance."""
     try:

--- a/docs/source/changelog/TBR_2.0.0.rst
+++ b/docs/source/changelog/TBR_2.0.0.rst
@@ -2,6 +2,13 @@
 2.0.0 (TBR)
 ###########
 
+*******
+General
+*******
+
+* Add (preliminary) support for storing private keys in a hardware security module (HSM). See
+  :doc:`/key_backends` for more information.
+
 **********************
 Command-line utilities
 **********************

--- a/docs/source/include/config/settings_hsm_backend.py
+++ b/docs/source/include/config/settings_hsm_backend.py
@@ -1,0 +1,10 @@
+CA_KEY_BACKENDS = {
+    "default": {
+        "BACKEND": "django_ca.key_backends.hsm.HSMBackend",
+        "OPTIONS": {
+            "library_path": "/usr/lib/softhsm/libsofthsm2.so",
+            "token": "my_token_label",
+            "user_pin": "secret_user_pin",
+        },
+    },
+}

--- a/docs/source/include/config/settings_hsm_backend.yaml
+++ b/docs/source/include/config/settings_hsm_backend.yaml
@@ -1,0 +1,7 @@
+CA_KEY_BACKENDS:
+    default:
+        BACKEND: django_ca.key_backends.hsm.HSMBackend
+        OPTIONS:
+            library_path: /usr/lib/softhsm/libsofthsm2.so
+            token: my_token_label
+            user_pin: secret_user_pin

--- a/docs/source/include/config/settings_multiple_ca_key_backends.py
+++ b/docs/source/include/config/settings_multiple_ca_key_backends.py
@@ -1,0 +1,18 @@
+STORAGES = {  # type: ignore[var-annotated]
+    # ... see default configuration
+}
+
+CA_KEY_BACKENDS = {
+    "default": {
+        "BACKEND": "django_ca.key_backends.storages.StoragesBackend",
+        "OPTIONS": {"storage_alias": "django-ca"},
+    },
+    "hsm": {
+        "BACKEND": "django_ca.key_backends.hsm.HSMBackend",
+        "OPTIONS": {
+            "library_path": "/usr/lib/softhsm/libsofthsm2.so",
+            "token": "my_token_label",
+            "user_pin": "secret_user_pin",
+        },
+    },
+}

--- a/docs/source/include/config/settings_multiple_ca_key_backends.yaml
+++ b/docs/source/include/config/settings_multiple_ca_key_backends.yaml
@@ -1,0 +1,14 @@
+STORAGES:
+  # ... see default configuration
+
+CA_KEY_BACKENDS:
+  default:
+    BACKEND: django_ca.key_backends.storages.StoragesBackend
+    OPTIONS:
+      storage_alias: django-ca
+  hsm:
+      BACKEND: django_ca.key_backends.hsm.HSMBackend
+      OPTIONS:
+          library_path: /usr/lib/softhsm/libsofthsm2.so
+          token: my_token_label
+          user_pin: secret_user_pin

--- a/docs/source/include/pip-extras.rst
+++ b/docs/source/include/pip-extras.rst
@@ -4,6 +4,7 @@ Extra         Description
 ============= ===============================================================================================
 ``api``       Adds support for the :doc:`/rest_api` using `Django Ninja <https://django-ninja.dev/>`_.
 ``celery``    Adds `Celery <https://docs.celeryproject.org/>`_ support.
+``hsm``       Adds support for hardware security modules (HSMs).
 ``mysql``     Adds MySQL support.
 ``postgres``  Adds PostgreSQL support using `Psycopg 3 <https://pypi.org/project/psycopg/>`_.
 ``redis``     Adds `Redis <https://redis.io/>`_ support (usable as both cache and Celery message transport).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,12 +34,13 @@ Welcome to django-ca's documentation!
    cli/intro
    Command-line interface: certificate authority management <cli/cas>
    Command-line interface: certificate management <cli/certs>
-   web_interface
    acme
+   key_backends
    rest_api
    profiles
    crl
    ocsp
+   web_interface
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -9,6 +9,7 @@ Features:
 #. Set up a secure local certificate authority in just a few minutes.
 #. Certificate revocation via CRLs and OCSP.
 #. Certificate issuance via ACMEv2, command line, web interface or REST API.
+#. **Preliminary** support for hardware security modules (HSMs).
 #. Management via command line and/or via Django's admin interface.
 #. Get email notifications about certificates about to expire.
 #. Written in Python 3.9+, Django 4.2+ and cryptography 42+.

--- a/docs/source/key_backends.rst
+++ b/docs/source/key_backends.rst
@@ -1,0 +1,166 @@
+############
+Key backends
+############
+
+**django-ca** allows you to store private keys of certificate authorities as files (on the file system or
+any other system supported via the `Django file storage API
+<https://docs.djangoproject.com/en/5.0/ref/files/storage/>`_) or in a hardware security module (HSM) using the
+#PKCS 11 protocol.
+
+You can even write your own backend for storing private keys to handle private keys in more unique ways, see
+:ref:`writing custom backends <custom_key_backends>` for more information.
+
+*********************
+Default configuration
+*********************
+
+The default configuration is to store private keys on the file system. This works on any system, but is not
+the most secure method possible.
+
+.. tab:: Python
+
+   .. literalinclude:: /include/config/settings_default_ca_key_backends.py
+      :language: python
+
+.. tab:: YAML
+
+   .. literalinclude:: /include/config/settings_default_ca_key_backends.yaml
+      :language: YAML
+
+*****************
+Multiple backends
+*****************
+
+You can configure multiple backends using the :ref:`settings-ca-key-backends` setting. For example, if you
+want to be able to store private keys on the file system, but also in a hardware security module (HSM):
+
+.. tab:: Python
+
+   .. literalinclude:: /include/config/settings_multiple_ca_key_backends.py
+      :language: python
+
+.. tab:: YAML
+
+   .. literalinclude:: /include/config/settings_multiple_ca_key_backends.yaml
+      :language: YAML
+
+Command-line options added by any backend that is not named "default" will be prefixed with the name of the
+backend. In the above example, you can use the ``--password`` option normally (which is added by the default
+backend), but you must use ``--hsm-user-pin`` etc. when using the HSM key backend:
+
+.. code-block:: console
+
+   user@host:~$ python manage.py init_ca --password=mypassword CAInDefaultKeyBackend CN=Default
+   user@host:~$ python manage.py init_ca --key-backend=hsm \
+   >     --hsm-key-label=my_key_label --hsm-user-pin=1234 \
+   >     CAInHSM CN=HSM
+
+If you run any command with ``--help``, you'll see all currently valid options.
+
+******************
+Supported backends
+******************
+
+.. _storages_backend:
+
+:spelling:word:`Storages` backend
+=================================
+
+The most common use case for this key backend is to store keys on the local file system. However, you can
+use any custom Django storage system, for example from `django-storages
+<https://django-storages.readthedocs.io/en/latest/>`_.
+
+This backend takes a single option, ``storage_alias``. It defines the storage system (as defined in
+`STORAGES <https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-STORAGES>`_) to use.
+The default configuration is a good example:
+
+.. tab:: Python
+
+   .. literalinclude:: /include/config/settings_default_ca_key_backends.py
+      :language: python
+
+.. tab:: YAML
+
+   .. literalinclude:: /include/config/settings_default_ca_key_backends.yaml
+      :language: YAML
+
+.. seealso::
+
+   * `STORAGES setting <https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-STORAGES>`_
+   * `Django file storage API <https://docs.djangoproject.com/en/5.0/ref/files/storage/>`_
+   * `django-storages <https://django-storages.readthedocs.io/en/latest/>`_
+
+.. _hsm_backend:
+
+HSM (Hardware Security Module) backend
+======================================
+
+The HSM backend provides the ability to store private keys in a Hardware Security Module (HSM) via the
+`PKCS 11 protocol <https://en.wikipedia.org/wiki/PKCS_11>`_ and `python-pkcs11
+<https://python-pkcs11.readthedocs.io/>`_.
+
+When using :doc:`Docker </quickstart/docker>` or :doc:`docker-compose </quickstart/docker_compose>`, you need
+to make sure that the PKCS 11 library as well as the hardware device is available in the Docker container.
+
+When using django-ca :doc:`as a Django app </quickstart/as_app>` or if you :doc:`installed from source
+</quickstart/from_source>`, you have to install django-ca with the ``hsm`` extra, e.g.
+
+.. code-block:: console
+
+   user@host:~$ pip install django-ca[hsm]
+
+This backend has several mandatory options:
+
+    * `library_path` specifies the path to the PKCS11 library (e.g.
+      ``/usr/lib/softhsm/libsofthsm2.so`` for SoftHSM2 on Debian/Ubuntu).
+    * `token` to specify the token to use.
+    * Either an `so_pin` or `user_pin` (can be overwritten on the command-line).
+
+For example:
+
+.. tab:: Python
+
+   .. literalinclude:: /include/config/settings_hsm_backend.py
+      :language: python
+
+.. tab:: YAML
+
+   .. literalinclude:: /include/config/settings_hsm_backend.yaml
+      :language: YAML
+
+Usage via the command-line
+--------------------------
+
+Assuming the HSM backend is the default backend, you can create a certificate authority and sign a certificate
+like this:
+
+.. code-block:: console
+
+   user@host:~$ python manage.py init_ca --key-label=my-key-label --user-pin=1234 CAInHSM CN=ca.example.com
+   user@host:~$ python manage.py sign_cert --ca=... --alt=example.com
+
+If the HSM backend is not the default backend but uses the name ``"hsm"``, you have to explicitly name the key
+backend and prefix options accordingly:
+
+.. code-block:: console
+
+    user@host:~$ python manage.py init_ca \
+    >     --key-backend=hsm --hsm-key-label=my-key-label --hsm-user-pin=1234 \
+    >     CAInHSM CN=ca.example.com
+    user@host:~$ python manage.py sign_cert --ca=... --alt=example.com
+
+.. _hsm_backend_pins:
+
+HSM pin handling
+----------------
+
+Any operation must either use an SO pin or a user pin. The configuration in ``CA_KEY_BACKENDS`` should
+provide the pin required for signing operations, usually the user pin.
+
+If creating a new certificate authority requires an SO pin instead, you can specify it on the command line.
+However, you must also disable the user pin in this case. For example (assuming the HSM backend is your
+default backend):
+
+.. code-block:: console
+
+   user@host:~$ python manage.py init_ca --so-pin=1234 --user-pin="" ...

--- a/docs/source/python/key_backends.rst
+++ b/docs/source/python/key_backends.rst
@@ -2,14 +2,10 @@
 ``django_ca.key_backends`` - Key backends
 #########################################
 
-**django-ca** key backends allow you to store private keys in multiple locations. An interface allows you to
+**django-ca** key backends allow you to store private keys in different locations. An interface allows you to
 write custom backends as well.
 
-**********************
-Supported key backends
-**********************
-
-.. autoclass:: django_ca.key_backends.storages.StoragesBackend
+.. _custom_key_backends:
 
 ***********************
 Writing custom backends
@@ -152,3 +148,10 @@ Base class documentation
 .. autoclass:: django_ca.key_backends.base.KeyBackend
    :members:
    :exclude-members: class_path
+
+Implementations
+===============
+
+.. autoclass:: django_ca.key_backends.storages.StoragesBackend
+
+.. autoclass:: django_ca.key_backends.hsm.HSMBackend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ dependencies = [
 [project.optional-dependencies]
 api = ["django-ninja>=1.1"]
 celery = ["celery>=5.4"]
+hsm = ["python-pkcs11>=0.7"]
 mysql = ["mysqlclient"]
 postgres = ["psycopg[c,pool]>=3.1"]
 redis = ["hiredis>=2.1.0", "redis>=4.6"]
@@ -194,6 +195,8 @@ module = [
     "docker.*",
     "enchant.tokenize",
     "httpcore.*",
+    "pkcs11.*",
+    "pkcs11.util.*",
     # psycopg and psycopg_c are not installed in isolated mypy envs (tox, ...)
     "psycopg",
     "psycopg_c",
@@ -391,7 +394,7 @@ filterwarnings = [
     "error:::acme",
     "error:::josepy",
     "error:::pydantic",
-
+    
     # acme==2.11.0; https://github.com/certbot/certbot/issues/8492
     #               https://github.com/certbot/certbot/issues/9828
     # josepy==1.14.0;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e .[celery,redis,yaml,api,postgres]
+-e .[celery,hsm,redis,yaml,api,postgres]


### PR DESCRIPTION
Implement HSM support. Also drop support for Pydantic 2.6 (some issues with inheritance we use in the HSM models) and add support for cryprography 43.